### PR TITLE
refactor(claude): make all model-facing context english

### DIFF
--- a/config/claude/CLAUDE.md
+++ b/config/claude/CLAUDE.md
@@ -199,4 +199,4 @@ Defense in depth. Git hooks can enforce this, but they live outside this config 
 
 ## Session Close
 
-Verificacion en verde (tests, linters, exit 0). Sin artefactos temporales, debug statements ni TODOs colgando. Con Engram: `mem_session_summary`.
+Verification green (tests, linters, exit 0). No temporary artifacts, no debug statements, no dangling TODOs. With Engram: `mem_session_summary`.

--- a/config/claude/agents/code-reviewer.md
+++ b/config/claude/agents/code-reviewer.md
@@ -133,7 +133,7 @@ Tag every finding with severity and confidence:
 - **Performance**: N+1 queries, missing indexes, unnecessary loops, memory leaks
 - **Error handling**: Missing try/catch, swallowed exceptions, leaked stack traces
 - **Testing**: Missing edge case tests, test only happy path, mocked too aggressively
-- **SDD Traceability**: Cada R<n> del spec tiene al menos un test que lo verifica. Boundary compliance: archivos modificados coinciden con `_Boundary:_` de las tareas
+- **SDD Traceability**: every R<n> in the spec has at least one test verifying it. Boundary compliance: modified files match the `_Boundary:_` of the tasks
 
 ### Auto-Fixable Patterns
 

--- a/config/claude/agents/frontend-developer.md
+++ b/config/claude/agents/frontend-developer.md
@@ -81,20 +81,20 @@ You are hermano with `ui-ux-designer`. ui-ux-designer defines the visual directi
 
 ```bash
 npx --yes zero-native@latest init my_app --frontend next  # next|react|vue|svelte
-zig build run                              # unico comando de build+run
-# Desarrollo: correr bundler aparte (Vite en :5173), WebView apunta a localhost
+zig build run                              # single build+run command
+# Development: run the bundler separately (Vite on :5173), WebView points to localhost
 ```
 
-No instales `zero-native` globalmente. Si el proyecto necesita fijar la
-dependencia, agrégala como `devDependency` y ejecútala con `npx` desde el
-proyecto.
+Do not install `zero-native` globally. If the project needs to pin the
+dependency, add it as a `devDependency` and run it with `npx` from the
+project.
 
-**app.zon** (manifiesto Zig):
+**app.zon** (Zig manifest):
 
 ```zig
 .{
     .id = "com.example.my-app",
-    .web_engine = "system",           // "system" (WKWebView/WebKitGTK) | "chromium" (CEF, solo macOS)
+    .web_engine = "system",           // "system" (WKWebView/WebKitGTK) | "chromium" (CEF, macOS only)
     .permissions = .{ "window" },
     .capabilities = .{ "webview", "js_bridge" },
     .security = .{ .navigation = .{ .allowed_origins = .{ "zero://app", "http://127.0.0.1:5173" } } },
@@ -102,11 +102,11 @@ proyecto.
 }
 ```
 
-**Web engines**: `system` → WKWebView (macOS), WebKitGTK (Linux) — no runtime bundle, binarios chicos. `chromium` → CEF, solo macOS builds, runtime externo.
+**Web engines**: `system` → WKWebView (macOS), WebKitGTK (Linux) — no runtime bundle, small binaries. `chromium` → CEF, macOS builds only, external runtime.
 
-**JS bridge**: `window.zero.invoke()` — size-limited, origin-checked, permission-checked. Solo handlers registrados. WebView tratado como no confiable por defecto.
+**JS bridge**: `window.zero.invoke()` — size-limited, origin-checked, permission-checked. Registered handlers only. The WebView is treated as untrusted by default.
 
-**Gotchas**: Pre-release (32 commits). Chromium solo macOS. Sin comando `dev` con HMR — correr Vite/Next dev aparte y apuntar WebView a localhost. CEF se descarga como runtime externo.
+**Gotchas**: Pre-release (32 commits). Chromium is macOS only. No `dev` command with HMR — run Vite/Next dev separately and point the WebView at localhost. CEF is downloaded as an external runtime.
 
 **Inertia.js**: Laravel ↔ React bridge, server-side routing, useForm, router.visit, persistent layouts.
 
@@ -171,13 +171,13 @@ ScrollXUI ships an MCP server — if configured, browse and reference components
 
 ## Google Stitch (stitch.withgoogle.com)
 
-Google I/O May 2025. Genera pantallas desde texto usando IA. **MCP first-party solo en OpenCode** (no disponible en Claude Code). Skills instalados en ambas plataformas.
+Google I/O May 2025. Generates screens from text using AI. **First-party MCP on OpenCode only** (not available in Claude Code). Skills are installed on both platforms.
 
-**Skills disponibles:**
+**Available skills:**
 
 | Skill | What it does | Needs MCP |
 | --- | --- | --- |
-| `enhance-prompt` | Transforma ideas vagas en prompts Stitch-optimizados | No |
+| `enhance-prompt` | Turns vague ideas into Stitch-optimized prompts | No |
 | `taste-design` | Generates DESIGN.md with anti-generic standards | No |
 | `design-md` | Analyzes Stitch projects and synthesizes DESIGN.md | Yes |
 | `stitch-generate-design` | Core generation: text->design, editing, variants | Yes |

--- a/config/claude/agents/technical-writer.md
+++ b/config/claude/agents/technical-writer.md
@@ -258,10 +258,10 @@ the task asks for that specific file. Invoke them with the `Skill` tool (`pptx`,
 
 ### PPTX — presentations, decks, slides
 
-Invoca la skill `pptx` (workflow, design, QA). Sub-archivos a leer SOLO cuando apliquen:
+Invoke the `pptx` skill (workflow, design, QA). Sub-files to read ONLY when they apply:
 
-- `~/.claude/skills/pptx/pptxgenjs.md` — si creas desde cero
-- `~/.claude/skills/pptx/editing.md` — si editas un template existente
+- `~/.claude/skills/pptx/pptxgenjs.md` — when creating from scratch
+- `~/.claude/skills/pptx/editing.md` — when editing an existing template
 
 `pptxgenjs` is declared in `~/.claude/skills/pptx/package.json`. If the skill's
 `node_modules/` directory is absent, run `npm install` inside that skill
@@ -276,7 +276,7 @@ QA required: content QA with `python -m markitdown file.pptx`, visual QA with su
 
 ### XLSX — spreadsheets, tabular data, financial models
 
-Invoca la skill `xlsx`.
+Invoke the `xlsx` skill.
 
 Helper scripts in `~/.claude/skills/xlsx/scripts/`. Recalculate formulas:
 
@@ -286,7 +286,7 @@ python ~/.claude/skills/xlsx/scripts/recalc.py file.xlsx
 
 ### DOCX — Word documents, INACAP academic format
 
-Invoca la skill `inacap`.
+Invoke the `inacap` skill.
 
 Template at `~/.claude/skills/inacap/template.py`.
 
@@ -296,24 +296,24 @@ Template at `~/.claude/skills/inacap/template.py`.
 the frontmatter when installed on the host. Use only those declared commands;
 do not assume unrestricted shell access.
 
-### Documentos (pandoc)
+### Documents (pandoc)
 
-Convertir entre formatos: MD <-> DOCX / PDF / HTML / EPUB / LaTeX / PPTX, con TOC, citas (`--citeproc --bibliography`), y templates corporativos (`--reference-doc`).
+Convert between formats: MD <-> DOCX / PDF / HTML / EPUB / LaTeX / PPTX, with TOC, citations (`--citeproc --bibliography`), and corporate templates (`--reference-doc`).
 
 ```bash
 pandoc input.md -o output.docx --reference-doc=template.docx
 pandoc input.md -o output.html --standalone --embed-resources
 ```
 
-PDF necesita engine LaTeX (`brew install tectonic` liviano, o `--cask basictex`). Sin engine, el export a PDF falla.
+PDF needs a LaTeX engine (`brew install tectonic` for a light one, or `--cask basictex`). Without an engine, PDF export fails.
 
-### Imagenes (imagemagick / magick)
+### Images (imagemagick / magick)
 
-Convertir/optimizar: WebP / AVIF / PNG / JPG / ICO, resize, compress, crop, watermark, favicon, thumbnails.
+Convert/optimize: WebP / AVIF / PNG / JPG / ICO, resize, compress, crop, watermark, favicon, thumbnails.
 
 ```bash
 magick input.png -quality 80 output.webp
 magick input.png -define icon:auto-resize=16,32,48 favicon.ico
 ```
 
-PDF <-> imagen necesita Ghostscript (`brew install ghostscript`). Sin el, ImageMagick falla con `no decode delegate for this image format PDF`.
+PDF <-> image needs Ghostscript (`brew install ghostscript`). Without it, ImageMagick fails with `no decode delegate for this image format PDF`.

--- a/config/claude/agents/vulnerability-hunter.md
+++ b/config/claude/agents/vulnerability-hunter.md
@@ -4,8 +4,8 @@ description: |
   Host-local vulnerability hunter for source code, dependencies, secrets, and container images. Use PROACTIVELY for defensive security review of the current repository. Network pentesting and exploit execution belong in the user's virtual machine, not on this host.
 
   <example>
-  user: "Revisa si este repositorio tiene secretos o dependencias vulnerables"
-  assistant: "Voy a ejecutar una revisión defensiva local y documentar evidencia reproducible."
+  user: "Check whether this repository has secrets or vulnerable dependencies"
+  assistant: "I'll run a local defensive review and document reproducible evidence."
   <commentary>
   Static security review and local dependency analysis trigger this agent.
   </commentary>

--- a/config/claude/commands/code-review.md
+++ b/config/claude/commands/code-review.md
@@ -1,22 +1,22 @@
 ---
-description: "Revisar cambios de código: diff, calidad, seguridad y arquitectura"
-argument-hint: "[rango de diff | archivos | vacío = staged]"
+description: "Review code changes: diff, quality, security and architecture"
+argument-hint: "[diff range | files | empty = staged]"
 ---
 
-Hacé una revisión de código exhaustiva de: $ARGUMENTS (si vacío, usá `git diff --staged`; si no hay staged, `git diff HEAD~1`).
+Perform an exhaustive code review of: $ARGUMENTS (if empty, use `git diff --staged`; if nothing is staged, `git diff HEAD~1`).
 
-Proceso:
-1. **Scope**: determiná el diff exacto a revisar.
-2. **Delegá** al agente `code-reviewer` con el diff.
-3. **Chequeá**:
-   - Corrección y edge cases
-   - Vulnerabilidades de seguridad (OWASP, inyección, auth)
-   - Implicaciones de performance
-   - Cobertura de tests de la lógica cambiada
-   - Naming, legibilidad, adherencia al estilo del proyecto
-4. **Reportá**:
-   - Severidad por hallazgo (Critical/High/Medium/Low/Info)
-   - Cobertura de requerimientos si existen
-   - Veredicto: approve / changes-requested / block
+Process:
+1. **Scope**: determine the exact diff to review.
+2. **Delegate** to the `code-reviewer` agent with the diff.
+3. **Check**:
+   - Correctness and edge cases
+   - Security vulnerabilities (OWASP, injection, auth)
+   - Performance implications
+   - Test coverage of the changed logic
+   - Naming, readability, adherence to the project style
+4. **Report**:
+   - Severity per finding (Critical/High/Medium/Low/Info)
+   - Requirements coverage when requirements exist
+   - Verdict: approve / changes-requested / block
 
-Siempre usá el agente `code-reviewer` para revisiones no triviales. Para fixes de 1 línea, revisá inline.
+Always use the `code-reviewer` agent for non-trivial reviews. For 1-line fixes, review inline.

--- a/config/claude/commands/model-route.md
+++ b/config/claude/commands/model-route.md
@@ -1,25 +1,25 @@
 ---
-description: "Elegir el modelo óptimo según complejidad, costo y latencia de la tarea"
-argument-hint: "[tarea a analizar]"
+description: "Pick the optimal model based on task complexity, cost and latency"
+argument-hint: "[task to analyze]"
 ---
 
-Analizá la tarea y recomendá el modelo óptimo: $ARGUMENTS.
+Analyze the task and recommend the optimal model: $ARGUMENTS.
 
-**Matriz de decisión** (modelos Claude disponibles en esta config):
+**Decision matrix** (Claude models available in this config):
 
-| Complejidad | Modelo | Caso de uso |
+| Complexity | Model | Use case |
 |---|---|---|
-| Trivial (typos, 1 línea) | haiku | Velocidad sobre inteligencia |
+| Trivial (typos, 1 line) | haiku | Speed over intelligence |
 | Standard (features, bugs) | sonnet | Balance |
-| Compleja (arquitectura, multi-agente) | opus | Máxima inteligencia |
-| Planificación pesada / specs | opusplan | Planificación larga |
-| Code review | opus + agente code-reviewer | Quality gate |
+| Complex (architecture, multi-agent) | opus | Maximum intelligence |
+| Heavy planning / specs | opusplan | Long-horizon planning |
+| Code review | opus + code-reviewer agent | Quality gate |
 
-**Factores a evaluar**:
-1. ¿Cuántos archivos hay que cambiar?
-2. ¿Hay lógica de seguridad/auth involucrada?
-3. ¿Es arquitectura o patrón nuevo?
-4. ¿Se necesitan subagentes?
-5. ¿Cuál es el presupuesto de costo/latencia?
+**Factors to evaluate**:
+1. How many files have to change?
+2. Is security/auth logic involved?
+3. Is it new architecture or a new pattern?
+4. Are subagents needed?
+5. What is the cost/latency budget?
 
-Output: modelo recomendado + rationale + estimación de token usage.
+Output: recommended model + rationale + token usage estimate.

--- a/config/claude/commands/plan.md
+++ b/config/claude/commands/plan.md
@@ -1,16 +1,16 @@
 ---
-description: "Planificar la implementación de una feature: arquitectura, fases y dependencias"
-argument-hint: "[feature a planificar]"
+description: "Plan a feature implementation: architecture, phases and dependencies"
+argument-hint: "[feature to plan]"
 ---
 
-Planificá la implementación de: $ARGUMENTS.
+Plan the implementation of: $ARGUMENTS.
 
-Proceso:
-1. **Explore**: leé los archivos relevantes del codebase.
-2. **Design**: arquitectura de la solución y patrones a usar.
-3. **Plan**: dividí en fases con dependencias claras.
-4. **Validate**: chequeá contra las reglas de `rules/common/`.
+Process:
+1. **Explore**: read the relevant files in the codebase.
+2. **Design**: solution architecture and patterns to use.
+3. **Plan**: split into phases with explicit dependencies.
+4. **Validate**: check against the rules in `rules/common/`.
 
-Si es una feature compleja o multi-archivo, usá la skill `sdd-workflow` con sus templates y gates.
+For a complex or multi-file feature, use the `sdd-workflow` skill with its templates and gates.
 
-No escribas código en esta fase. Solo diseño y plan.
+Do not write code in this phase. Design and plan only.

--- a/config/claude/commands/security-scan.md
+++ b/config/claude/commands/security-scan.md
@@ -1,33 +1,33 @@
 ---
-description: "Auditoría de seguridad completa: dependencias, secretos, OWASP y permisos"
-argument-hint: "[ruta del proyecto | vacío = directorio actual]"
+description: "Full security audit: dependencies, secrets, OWASP and permissions"
+argument-hint: "[project path | empty = current directory]"
 ---
 
-Ejecutá un escaneo de seguridad completo de: $ARGUMENTS (si vacío, el directorio actual).
+Run a full security scan of: $ARGUMENTS (if empty, the current directory).
 
-1. **Dependency audit**: corré el audit del runner del proyecto (`npm audit`, `bun audit`, `pnpm audit`, o `pip-audit`).
-2. **Detección de secretos**: buscá hardcoded secrets, API keys y tokens en archivos fuente.
-3. **OWASP quick check**: revisá patrones de auth, validación de input y manejo de errores contra el top 10.
-4. **Permission review**: permisos de archivos, cobertura de .gitignore, exposición de archivos sensibles.
-5. **Supply chain**: integridad del lockfile, dependencias git, provenance (usá la skill `npm-security` para proyectos JS/TS).
+1. **Dependency audit**: run the project runner's audit (`npm audit`, `bun audit`, `pnpm audit`, or `pip-audit`).
+2. **Secret detection**: look for hardcoded secrets, API keys and tokens in source files.
+3. **OWASP quick check**: review auth patterns, input validation and error handling against the top 10.
+4. **Permission review**: file permissions, .gitignore coverage, exposure of sensitive files.
+5. **Supply chain**: lockfile integrity, git dependencies, provenance (use the `npm-security` skill for JS/TS projects).
 
-## Agentes
+## Agents
 
-Levantá **`vulnerability-hunter` siempre**: es el único que tiene las herramientas
-de escaneo en su allowlist (`semgrep`, `gitleaks`, `bandit`, `npm audit`,
-`pip-audit`, `trivy`, más el análisis de binarios), así que es el que ejecuta los
-pasos 1, 2 y la parte verificable del 5. Los demás agentes solo pueden opinar
-sobre esos puntos; este los corre.
+Spawn **`vulnerability-hunter` always**: it is the only one with the scanning
+tools in its allowlist (`semgrep`, `gitleaks`, `bandit`, `npm audit`,
+`pip-audit`, `trivy`, plus binary analysis), so it is the one that executes
+steps 1, 2 and the verifiable part of 5. The other agents can only opine on
+those points; this one runs them.
 
-Sumá `security-auditor` en paralelo cuando el proyecto no sea trivial o el paso 3
-importe: aporta el lente de threat model, OWASP y arquitectura de auth, que es
-juicio de diseño y no sale de un scanner.
+Add `security-auditor` in parallel when the project is non-trivial or step 3
+matters: it brings the threat model, OWASP and auth architecture lens, which is
+design judgment and does not come out of a scanner.
 
-Si una herramienta no está instalada en el host, reportá esa etapa como **no
-ejecutada**. Un scanner ausente no es un hallazgo limpio: presentarlo como verde
-es peor que no correrlo, porque compra confianza que nadie verificó.
+If a tool is not installed on the host, report that stage as **not executed**.
+A missing scanner is not a clean finding: presenting it as green is worse than
+not running it, because it buys confidence nobody verified.
 
-Formato de reporte:
-- Severidad: Critical / High / Medium / Low / Info
-- Por hallazgo: descripción, archivo:línea, remediación
-- Resumen ejecutivo con risk score
+Report format:
+- Severity: Critical / High / Medium / Low / Info
+- Per finding: description, file:line, remediation
+- Executive summary with risk score

--- a/config/claude/hooks/check-auto-save-stash.sh
+++ b/config/claude/hooks/check-auto-save-stash.sh
@@ -2,8 +2,8 @@
 # SessionStart: checkea si hay stashes de auto-save pendientes del PreCompact
 STASHES=$(git -C "$PWD" stash list --grep="auto-save:" 2>/dev/null)
 if [ -n "$STASHES" ]; then
-  echo "[SessionStart] ⚠️  AUTO-SAVE STASHES PENDIENTES en $PWD:" >&2
+  echo "[SessionStart] ⚠️  PENDING AUTO-SAVE STASHES in $PWD:" >&2
   echo "$STASHES" >&2
-  echo "   Recuperá con: git stash pop" >&2
+  echo "   Recover with: git stash pop" >&2
 fi
 exit 0

--- a/config/claude/hooks/compact-resume.py
+++ b/config/claude/hooks/compact-resume.py
@@ -38,26 +38,26 @@ except (OSError, subprocess.SubprocessError):
 
 status_lines = status.splitlines()[:40]
 if len(status.splitlines()) > 40:
-    status_lines.append(f'... (+{len(status.splitlines()) - 40} archivos mas)')
-status_block = '\n'.join(status_lines) or 'working tree limpio'
+    status_lines.append(f'... (+{len(status.splitlines()) - 40} more files)')
+status_block = '\n'.join(status_lines) or 'working tree clean'
 
-context = f"""CONTEXTO COMPACTADO. Las reglas NO se relajan post-compactacion.
+context = f"""CONTEXT COMPACTED. The rules are NOT relaxed after compaction.
 
-Siguen vigentes TODAS las de CLAUDE.md y rules/common/*.md — NO AI FOOTPRINT,
-VERIFY FIRST (sin "should work"), EVIDENCE BEFORE CLAIMS, LEVERAGE != RELY
-(ownership total, CI != seguro), PRE-COMMIT LITMUS (3 preguntas), GOAL-DRIVEN
-(loop hasta verificado), STOP & WAIT ante ambiguedad.
+ALL of CLAUDE.md and rules/common/*.md remain in force — NO AI FOOTPRINT,
+VERIFY FIRST (no "should work"), EVIDENCE BEFORE CLAIMS, LEVERAGE != RELY
+(full ownership, CI != guarantee), PRE-COMMIT LITMUS (3 questions), GOAL-DRIVEN
+(loop until verified), STOP & WAIT on ambiguity.
 
-Protocolo de reanudacion (rules/common/context-management.md):
-1. Re-lee los archivos que estabas editando. NO confies en tu resumen de su
-   contenido por encima del archivo.
-2. `mem_context` y `mem_search` para recuperar el razonamiento de decisiones ya
-   tomadas, en vez de re-derivarlas.
-3. NO re-litigues una decision que el usuario ya aprobo.
-4. La compactacion no es fin de tarea: retoma el trabajo pendiente, no cierres
-   con un resumen.
+Resumption protocol (rules/common/context-management.md):
+1. Re-read the files you were editing. Do NOT trust your summary of their
+   contents over the file.
+2. `mem_context` and `mem_search` to recover the reasoning behind decisions
+   already made, instead of re-deriving them.
+3. Do NOT re-litigate a decision the user already approved.
+4. Compaction is not the end of the task: resume the pending work, do not close
+   with a summary.
 
-git status actual:
+current git status:
 {status_block}"""
 
 print(json.dumps({

--- a/config/claude/hooks/detect-debug.sh
+++ b/config/claude/hooks/detect-debug.sh
@@ -31,9 +31,9 @@ esac
 FOUND=$(grep -nE '^[[:space:]]*(console\.(log|warn|error|debug)|print\(|var_dump\(|dd\(|debugger|binding\.pry|byebug|pdb\.set_trace|breakpoint\(\))' "$FILE_PATH" 2>/dev/null || true)
 
 if [ -n "$FOUND" ]; then
-  echo "[detect-debug] Debug statements en $FILE_PATH:" >&2
+  echo "[detect-debug] Debug statements in $FILE_PATH:" >&2
   echo "$FOUND" | head -10 >&2
-  echo "[detect-debug] Sacalos antes de declarar la tarea terminada." >&2
+  echo "[detect-debug] Remove them before declaring the task finished." >&2
 fi
 
 exit 0

--- a/config/claude/hooks/gauntlet-stop.sh
+++ b/config/claude/hooks/gauntlet-stop.sh
@@ -124,22 +124,22 @@ if [ -z "${CLAUDE_SKIP_TEST_RUN:-}" ]; then
     TEST_RC=$?
 
     if [ "$TEST_RC" = 124 ]; then
-      echo "[gauntlet] la suite no termino en 90s; no se pudo verificar. NO la des por verde." >&2
+      echo "[gauntlet] the suite did not finish in 90s; it could not be verified. Do NOT call it green." >&2
     elif [ "$TEST_RC" != 0 ]; then
       {
-        echo "GAUNTLET: la suite esta ROJA. No cierres el turno."
+        echo "GAUNTLET: the suite is RED. Do not close the turn."
         echo ""
         echo "$TEST_OUT" | tail -30
         echo ""
-        echo "ORDEN DE DIAGNOSTICO (rules/common/testing.md) — no lo saltees:"
-        echo "  1. El codigo nuevo esta mal -> arreglalo. NO toques el test."
-        echo "  2. Rompiste un contrato que otro codigo usaba -> adapta tu implementacion."
-        echo "  3. El test es fragil (orden, reloj, mock viejo) -> arregla la fragilidad,"
-        echo "     NO lo que verifica."
-        echo "  4. Recien aca: el test esta mal escrito -> PARA y pedi autorizacion"
-        echo "     diciendo que test, por que, y que cubre despues."
+        echo "DIAGNOSIS ORDER (rules/common/testing.md) — do not skip it:"
+        echo "  1. The new code is wrong -> fix it. Do NOT touch the test."
+        echo "  2. You broke a contract other code relied on -> adapt your implementation."
+        echo "  3. The test is flaky (order, clock, stale mock) -> fix the flakiness,"
+        echo "     NOT what it verifies."
+        echo "  4. Only here: the test is wrong -> STOP and ask for authorization"
+        echo "     stating which test, why, and what stays covered afterwards."
         echo ""
-        echo "Nunca saltes al 4 porque es el camino mas corto al verde."
+        echo "Never jump to 4 because it is the shortest path to green."
       } >&2
       exit 2
     fi
@@ -149,15 +149,15 @@ fi
 [ -z "$MISSING" ] && exit 0
 
 {
-  echo "GAUNTLET: hay codigo de produccion sin test."
+  echo "GAUNTLET: there is production code with no test."
   echo ""
   printf '%s' "$MISSING"
   echo ""
   echo "rules/common/testing.md: ALL code requires tests. No exceptions."
-  echo "Escribi el test antes de cerrar el turno."
+  echo "Write the test before closing the turn."
   echo ""
-  echo "Si de verdad no corresponde (spike, scratch, prototipo descartable),"
-  echo "decilo explicitamente al usuario y pedile que corra: touch .claude-relaxed"
+  echo "If it genuinely does not apply (spike, scratch, throwaway prototype),"
+  echo "say so explicitly to the user and ask them to run: touch .claude-relaxed"
 } >&2
 
 exit 2

--- a/config/claude/hooks/handoff-session-start.py
+++ b/config/claude/hooks/handoff-session-start.py
@@ -32,12 +32,12 @@ output = {
     "hookSpecificOutput": {
         "hookEventName": "SessionStart",
         "additionalContext": (
-            "📋 **HANDOFF de sesión anterior detectado:**\n\n"
+            "📋 **HANDOFF from a previous session detected:**\n\n"
             f"{content}\n\n"
             "---\n"
-            "**INSTRUCCIÓN:** Leé el handoff arriba. Contiene objetivo, estado actual, "
-            "archivos clave, cambios hechos, intentos fallidos y próximos pasos. "
-            "Continuá EXACTAMENTE desde donde se dejó. No repitas trabajo ya hecho."
+            "**INSTRUCTION:** Read the handoff above. It contains the goal, current state, "
+            "key files, changes made, failed attempts and next steps. "
+            "Continue EXACTLY from where it was left. Do not repeat work already done."
         )
     }
 }

--- a/config/claude/hooks/handoff-stop.sh
+++ b/config/claude/hooks/handoff-stop.sh
@@ -22,5 +22,5 @@ MARKER="${TMPDIR:-/tmp}/claude-handoff-hint-${SESSION_ID:-nosession}"
 [ -f "$MARKER" ] && exit 0
 : >"$MARKER"
 
-echo "[Hook] 💡 ¿Sesion larga o dando vueltas? Corre /handoff antes de cerrar para crear un traspaso limpio." >&2
+echo "[Hook] 💡 Long session or going in circles? Run /handoff before closing to create a clean handoff." >&2
 exit 0

--- a/config/claude/hooks/privacy-review.sh
+++ b/config/claude/hooks/privacy-review.sh
@@ -12,16 +12,16 @@ cmd_str=""
 # Extract command from JSON stdin
 if command -v jq &>/dev/null; then
   if ! cmd_str="$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)"; then
-    echo "[Privacy Review] BLOCKED — no se pudo parsear el input del hook; no se puede revisar el contenido antes de publicar en GitHub." >&2
+    echo "[Privacy Review] BLOCKED — could not parse the hook input; the content cannot be reviewed before publishing to GitHub." >&2
     exit 2
   fi
 elif command -v python3 &>/dev/null; then
   if ! cmd_str="$(printf '%s' "$input" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null)"; then
-    echo "[Privacy Review] BLOCKED — python3 no pudo parsear el input del hook; no se puede revisar el contenido antes de publicar en GitHub." >&2
+    echo "[Privacy Review] BLOCKED — python3 could not parse the hook input; the content cannot be reviewed before publishing to GitHub." >&2
     exit 2
   fi
 else
-  echo "[Privacy Review] BLOCKED — jq/python3 no esta disponible; no se puede revisar el contenido antes de publicar en GitHub." >&2
+  echo "[Privacy Review] BLOCKED — jq/python3 is not available; the content cannot be reviewed before publishing to GitHub." >&2
   exit 2
 fi
 

--- a/config/claude/hooks/project-integrations-check.sh
+++ b/config/claude/hooks/project-integrations-check.sh
@@ -49,24 +49,24 @@ codegraph_mcp_detail=""
 MCP_CONFIG="${CLAUDE_CONFIG:-$HOME/.claude.json}"
 if [ ! -f "$MCP_CONFIG" ] || ! jq -e '.mcpServers.codegraph.command // empty' "$MCP_CONFIG" >/dev/null 2>&1; then
   codegraph_mcp_state="NOT_CONFIGURED"
-  codegraph_mcp_detail="No se encontró el servidor CodeGraph en la configuración global de Claude."
+  codegraph_mcp_detail="The CodeGraph server was not found in the global Claude configuration."
 fi
 
 codegraph_state="READY"
 codegraph_detail=""
 if [ -z "$CODEGRAPH_BIN" ] || [ ! -x "$CODEGRAPH_BIN" ]; then
   codegraph_state="CLI_MISSING"
-  codegraph_detail="No se encontró el CLI codegraph en el PATH."
+  codegraph_detail="The codegraph CLI was not found in PATH."
 else
   CODEGRAPH_STATUS=$("$CODEGRAPH_BIN" status --json "$CWD" 2>/dev/null || true)
   CODEGRAPH_INITIALIZED=$(printf '%s' "$CODEGRAPH_STATUS" | jq -r '.initialized // false' 2>/dev/null || printf 'false')
   CODEGRAPH_INDEX=$(printf '%s' "$CODEGRAPH_STATUS" | jq -r '.indexPath // empty' 2>/dev/null || true)
   if [ "$CODEGRAPH_INITIALIZED" != "true" ]; then
     codegraph_state="NOT_INITIALIZED"
-    codegraph_detail="El proyecto no tiene un índice CodeGraph inicializado."
+    codegraph_detail="The project has no initialized CodeGraph index."
   elif [ -z "$CODEGRAPH_INDEX" ] || [ ! -d "$CODEGRAPH_INDEX" ]; then
     codegraph_state="BROKEN"
-    codegraph_detail="CodeGraph reporta inicialización, pero falta su directorio de índice."
+    codegraph_detail="CodeGraph reports it is initialized, but its index directory is missing."
   fi
 fi
 
@@ -76,7 +76,7 @@ if git -C "$CWD" rev-parse --show-toplevel >/dev/null 2>&1; then
   CODEGRAPH_TRACKED_PATH=$(git -C "$CWD" ls-files -- .codegraph 2>/dev/null | head -n 1 || true)
   if [ -n "$CODEGRAPH_TRACKED_PATH" ]; then
     codegraph_gitignore_state="TRACKED_EXISTING"
-    codegraph_gitignore_detail="CodeGraph ya estaba versionado; se conserva y no se cambia su tracking."
+    codegraph_gitignore_detail="CodeGraph was already versioned; that tracking is preserved and left unchanged."
   else
     CODEGRAPH_IGNORE_MATCH=$(git -C "$CWD" check-ignore -v -- .codegraph/ 2>/dev/null || true)
     CODEGRAPH_IGNORE_SOURCE=${CODEGRAPH_IGNORE_MATCH%%:*}
@@ -84,7 +84,7 @@ if git -C "$CWD" rev-parse --show-toplevel >/dev/null 2>&1; then
       codegraph_gitignore_state="CONFIGURED"
     else
       codegraph_gitignore_state="NOT_CONFIGURED"
-      codegraph_gitignore_detail="La raíz del proyecto no ignora .codegraph/ en su .gitignore."
+      codegraph_gitignore_detail="The project root does not ignore .codegraph/ in its .gitignore."
     fi
   fi
 fi
@@ -101,7 +101,7 @@ if [ -d "$CWD/openspec" ] || [ "${OPENSPEC_REQUIRED:-false}" = "true" ]; then
   OPENSPEC_TRACKED_PATH=$(git -C "$CWD" ls-files -- openspec 2>/dev/null | head -n 1 || true)
   if [ -n "$OPENSPEC_TRACKED_PATH" ]; then
     openspec_gitignore_state="TRACKED_EXISTING"
-    openspec_gitignore_detail="OpenSpec ya estaba versionado; se conserva y no se cambia su tracking."
+    openspec_gitignore_detail="OpenSpec was already versioned; that tracking is preserved and left unchanged."
   else
     OPENSPEC_IGNORE_MATCH=$(git -C "$CWD" check-ignore -v -- openspec/ 2>/dev/null || true)
     OPENSPEC_IGNORE_SOURCE=${OPENSPEC_IGNORE_MATCH%%:*}
@@ -109,18 +109,18 @@ if [ -d "$CWD/openspec" ] || [ "${OPENSPEC_REQUIRED:-false}" = "true" ]; then
       openspec_gitignore_state="CONFIGURED"
     else
       openspec_gitignore_state="NOT_CONFIGURED"
-      openspec_gitignore_detail="La raíz del proyecto no ignora openspec/ en su .gitignore."
+      openspec_gitignore_detail="The project root does not ignore openspec/ in its .gitignore."
     fi
   fi
   if [ -z "$OPENSPEC_BIN" ] || [ ! -x "$OPENSPEC_BIN" ]; then
     openspec_state="CLI_MISSING"
-    openspec_detail="El proyecto usa OpenSpec, pero no se encontró el CLI openspec en el PATH."
+    openspec_detail="The project uses OpenSpec, but the openspec CLI was not found in PATH."
   elif [ ! -d "$CWD/openspec/specs" ] || [ ! -d "$CWD/openspec/changes" ]; then
     openspec_state="NOT_INITIALIZED"
-    openspec_detail="Falta la estructura openspec/specs + openspec/changes."
+    openspec_detail="The openspec/specs + openspec/changes structure is missing."
   elif ! (cd "$CWD" && "$OPENSPEC_BIN" status --json >/dev/null 2>&1); then
     openspec_state="BROKEN"
-    openspec_detail="OpenSpec está presente, pero openspec status --json no pasa."
+    openspec_detail="OpenSpec is present, but openspec status --json does not pass."
   else
     openspec_state="READY"
   fi
@@ -135,7 +135,7 @@ if [ "$codegraph_state" = "READY" ] && [ "$codegraph_mcp_state" = "CONFIGURED" ]
 fi
 
 MESSAGE=$(cat <<EOF
-PROJECT PREFLIGHT: faltan o están incompletas integraciones del proyecto en $CWD.
+PROJECT PREFLIGHT: project integrations are missing or incomplete in $CWD.
 
 CodeGraph: $codegraph_state${codegraph_detail:+ — $codegraph_detail}
 CodeGraph MCP: $codegraph_mcp_state${codegraph_mcp_detail:+ — $codegraph_mcp_detail}
@@ -143,12 +143,12 @@ CodeGraph .gitignore: $codegraph_gitignore_state${codegraph_gitignore_detail:+ �
 OpenSpec: $openspec_state${openspec_detail:+ — $openspec_detail}
 OpenSpec .gitignore: $openspec_gitignore_state${openspec_gitignore_detail:+ — $openspec_gitignore_detail}
 
-Antes de explorar o modificar código, no asumas que estas integraciones están disponibles:
-1. CodeGraph: si falta su MCP, ejecutá \`codegraph install\`; luego ejecutá \`codegraph init\` dentro del proyecto y verificá con \`codegraph status --json\`.
-2. Git: agregá ".codegraph/" al archivo ".gitignore" de la raíz del proyecto antes de continuar.
-3. OpenSpec: instalá el CLI y ejecutá "openspec init" con autorización explícita; mantené "openspec/" en el ".gitignore" salvo que ya estuviera trackeado. Luego verificá "openspec status --json".
+Before exploring or modifying code, do not assume these integrations are available:
+1. CodeGraph: if its MCP is missing, run \`codegraph install\`; then run \`codegraph init\` inside the project and verify with \`codegraph status --json\`.
+2. Git: add ".codegraph/" to the project root ".gitignore" before continuing.
+3. OpenSpec: install the CLI and run "openspec init" with explicit authorization; keep "openspec/" in ".gitignore" unless it was already tracked. Then verify with "openspec status --json".
 
-No ejecutes esos comandos silenciosamente: pueden crear archivos del proyecto. Pedí autorización o indicá el bloqueo. No afirmes que CodeGraph MCP, el índice, la exclusión de ".codegraph/", OpenSpec o la exclusión de "openspec/" funcionan hasta contar con esa evidencia. Las consultas de configuración/documentación pueden continuar sin editar código.
+Do not run those commands silently: they can create project files. Ask for authorization or report the blocker. Do not claim that CodeGraph MCP, the index, the ".codegraph/" exclusion, OpenSpec or the "openspec/" exclusion work until you have that evidence. Configuration/documentation questions may continue without editing code.
 EOF
 )
 

--- a/config/claude/hooks/protect-codegraph-tracking.sh
+++ b/config/claude/hooks/protect-codegraph-tracking.sh
@@ -5,7 +5,7 @@
 set -u
 
 if ! command -v jq >/dev/null 2>&1; then
-  echo "[protect-codegraph-tracking] jq no esta instalado: bloqueo preventivo; instalalo con: brew install jq" >&2
+  echo "[protect-codegraph-tracking] jq is not installed: blocking preventively; install it with: brew install jq" >&2
   exit 2
 fi
 
@@ -48,7 +48,7 @@ for artifact in ".codegraph:CodeGraph" "openspec:OpenSpec"; do
   # A staged addition is never committed by the agent unless the explicit
   # override is present. Existing tracked files are not affected.
   if [ -n "$STAGED_ADD" ] && [ "$IS_COMMIT" = true ]; then
-    deny "No agregues al commit un artefacto $LABEL creado en esta sesión. Si el repositorio ya lo versionaba antes, preservá ese estado; para una excepción explícita usá AI_ARTIFACT_TRACKING_OVERRIDE=1."
+    deny "Do not add to the commit a $LABEL artifact created in this session. If the repository already versioned it before, preserve that state; for an explicit exception use AI_ARTIFACT_TRACKING_OVERRIDE=1."
   fi
 
   # Existing tracked artifacts are preserved exactly as requested.
@@ -59,7 +59,7 @@ for artifact in ".codegraph:CodeGraph" "openspec:OpenSpec"; do
   git -C "$ROOT" check-ignore -q -- "$RELATIVE_PATH/" && continue
 
   if [ "$IS_ADD" = true ] && [ "$ONLY_GITIGNORE_ADD" = false ]; then
-    deny "No stages $RELATIVE_PATH: fue creado en esta sesión y no está protegido por el .gitignore raíz. Agregá $RELATIVE_PATH/ al .gitignore y recién después usá git add; sólo una instrucción explícita del usuario puede cambiar esta regla."
+    deny "Do not stage $RELATIVE_PATH: it was created in this session and is not protected by the root .gitignore. Add $RELATIVE_PATH/ to .gitignore and only then use git add; only an explicit user instruction can change this rule."
   fi
 done
 

--- a/config/claude/hooks/protect-tests.sh
+++ b/config/claude/hooks/protect-tests.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 # Fallar cerrado evita que la ausencia del parser permita una edición que debía
 # quedar bloqueada.
 if ! command -v jq >/dev/null 2>&1; then
-  echo "[protect-tests] jq no esta instalado: bloqueo preventivo; instalalo con: brew install jq" >&2
+  echo "[protect-tests] jq is not installed: blocking preventively; install it with: brew install jq" >&2
   exit 2
 fi
 
@@ -104,4 +104,4 @@ if [ -f "$OWNED" ] && grep -qxF -- "$FILE_PATH" "$OWNED" 2>/dev/null; then
   allow
 fi
 
-deny "PROTECCION DE TESTS: '$BASENAME' ya existia al empezar esta sesion, asi que es cobertura que verifica tu trabajo y no un borrador tuyo. No la modifiques por tu cuenta. Si el cambio es legitimo (el requisito cambio de verdad), DETENETE y pedile autorizacion explicita al usuario explicando: (1) que test tocas, (2) por que, (3) que cubre despues del cambio. Nunca borres ni debilites un test para que el codigo pase. NOTA: este hook solo cubre Edit/Write/NotebookEdit — una escritura por Bash lo esquiva. Que sea posible no lo hace permitido: esquivarlo es violar la regla, no encontrarle la vuelta."
+deny "TEST PROTECTION: '$BASENAME' already existed when this session started, so it is coverage that verifies your work and not a draft of yours. Do not modify it on your own. If the change is legitimate (the requirement genuinely changed), STOP and ask the user for explicit authorization, stating: (1) which test you are touching, (2) why, (3) what it covers after the change. Never delete or weaken a test to make the code pass. NOTE: this hook only covers Edit/Write/NotebookEdit — a write through Bash slips past it. That it is possible does not make it permitted: bypassing it is breaking the rule, not working around it."

--- a/config/claude/hooks/quality-gate.sh
+++ b/config/claude/hooks/quality-gate.sh
@@ -19,7 +19,7 @@
 # jq es obligatorio: sin el, este hook no puede ejecutar el gate de commit.
 # Fallar cerrado evita que un commit escape sin la verificación requerida.
 if ! command -v jq >/dev/null 2>&1; then
-  echo "[quality-gate] jq no esta instalado: commit bloqueado; instalalo con: brew install jq" >&2
+  echo "[quality-gate] jq is not installed: commit blocked; install it with: brew install jq" >&2
   exit 2
 fi
 
@@ -128,16 +128,16 @@ block() {
   # el kill switch relajaba la mitad del gate y la otra mitad seguia frenando,
   # sin que nada lo dijera.
   if [ "$RELAXED" = true ]; then
-    echo "[quality-gate] AVISO (no bloquea, $RELAX_FILE): $msg" >&2
+    echo "[quality-gate] WARNING (not blocking, $RELAX_FILE): $msg" >&2
     [ -n "$output" ] && echo "$output" | tail -20 >&2
     return 0
   fi
 
   echo "[quality-gate] COMMIT BLOCKED: $msg" >&2
   if [ -n "$output" ]; then
-    echo "[quality-gate] --- salida del comando (ultimas 40 lineas) ---" >&2
+    echo "[quality-gate] --- command output (last 40 lines) ---" >&2
     echo "$output" | tail -40 >&2
-    echo "[quality-gate] --- fin de la salida ---" >&2
+    echo "[quality-gate] --- end of output ---" >&2
   fi
   echo "[quality-gate] Fix the issue and retry. Do NOT use --no-verify." >&2
   exit 2
@@ -163,11 +163,11 @@ if [ -x "$RDD" ] && [ ! -f "$ROOT/.claude-rdd/enabled" ] && [ "$RELAXED" = false
   if [ -n "$RISKY" ]; then
     bash "$RDD" on >/dev/null 2>&1 || true
     {
-      echo "[quality-gate] RDD ENCENDIDO AUTOMATICAMENTE en este repo."
-      echo "[quality-gate] El diff toca zona de riesgo:"
+      echo "[quality-gate] RDD TURNED ON AUTOMATICALLY in this repo."
+      echo "[quality-gate] The diff touches a risk zone:"
       printf '%s\n' "$RISKY" | sed 's/^/[quality-gate]   - /'
-      echo "[quality-gate] Desde ahora este repo exige recibo para commitear."
-      echo "[quality-gate] Apagalo con 'rdd off' si fue un falso positivo."
+      echo "[quality-gate] From now on this repo requires a receipt to commit."
+      echo "[quality-gate] Turn it off with 'rdd off' if this was a false positive."
     } >&2
   fi
 fi
@@ -182,13 +182,13 @@ if [ -x "$RDD" ] && [ -f "$ROOT/.claude-rdd/enabled" ]; then
   RDD_RC=$?
   RDD_MSG=""
   case $RDD_RC in
-    1) RDD_MSG="RDD encendido y no hay recibo.
-[quality-gate]   1) rdd freeze          congela los bytes staged
-[quality-gate]   2) revisa sobre ellos
-[quality-gate]   3) rdd receipt '<cmd de tests>'
-[quality-gate] Apagalo con 'rdd off' si este repo no lo necesita." ;;
-    2) RDD_MSG="el recibo es de OTROS bytes. El codigo cambio despues del review.
-[quality-gate] Volve a congelar y revisa de nuevo. 'rdd status' muestra el detalle." ;;
+    1) RDD_MSG="RDD is on and there is no receipt.
+[quality-gate]   1) rdd freeze          freezes the staged bytes
+[quality-gate]   2) review those bytes
+[quality-gate]   3) rdd receipt '<test cmd>'
+[quality-gate] Turn it off with 'rdd off' if this repo does not need it." ;;
+    2) RDD_MSG="the receipt is for OTHER bytes. The code changed after the review.
+[quality-gate] Freeze again and review once more. 'rdd status' shows the detail." ;;
   esac
   # Via block() y no exit 2 directo, para que el kill switch y el modo autonomo
   # lo degraden igual que al resto del gate.
@@ -354,7 +354,7 @@ if [ -n "$STAGED_FILES_FOR_DETECT" ]; then
     is_docs_or_config "$f" || { ALL_NON_CODE=false; break; }
   done <<< "$STAGED_FILES_FOR_DETECT"
   if [ "$ALL_NON_CODE" = true ]; then
-    echo "[quality-gate] Commit sin codigo (docs/config/assets) — sin gate de tests." >&2
+    echo "[quality-gate] Commit with no code (docs/config/assets) — no test gate." >&2
     exit 0
   fi
 fi
@@ -386,12 +386,12 @@ for PROJECT_DIR in "${PROJECT_DIRS[@]}"; do
   # dejaba commitear igual, o sea era un cartel, no una puerta.
   if [ "$HAS_TESTS" = false ]; then
     if [ "$RELAXED" = true ]; then
-      echo "[quality-gate] [$LABEL] sin test runner; $RELAX_FILE presente, se deja pasar." >&2
+      echo "[quality-gate] [$LABEL] no test runner; $RELAX_FILE present, letting it through." >&2
       continue
     fi
-    block "[$LABEL] no hay test runner en este proyecto y ALL code requires tests (rules/common/testing.md).
-[quality-gate] Configura uno ANTES de escribir codigo de produccion. Si este repo es un scratch
-[quality-gate] o un spike, creá el kill switch: touch $RELAX_FILE"
+    block "[$LABEL] there is no test runner in this project and ALL code requires tests (rules/common/testing.md).
+[quality-gate] Configure one BEFORE writing production code. If this repo is a scratch
+[quality-gate] or a spike, create the kill switch: touch $RELAX_FILE"
   fi
 
   # 1. Lint (if available)
@@ -459,10 +459,10 @@ for PROJECT_DIR in "${PROJECT_DIRS[@]}"; do
 
     if [ -n "$COV_FAIL" ]; then
       if [ "$RELAXED" = true ]; then
-        printf '[quality-gate] [%s] cobertura bajo el piso (%s presente, no bloquea):\n%s' "$LABEL" "$RELAX_FILE" "$COV_FAIL" >&2
+        printf '[quality-gate] [%s] coverage below the floor (%s present, not blocking):\n%s' "$LABEL" "$RELAX_FILE" "$COV_FAIL" >&2
       else
-        block "[$LABEL] cobertura bajo el piso:
-${COV_FAIL}[quality-gate] Agrega tests. Kill switch para este repo: touch $RELAX_FILE"
+        block "[$LABEL] coverage below the floor:
+${COV_FAIL}[quality-gate] Add tests. Kill switch for this repo: touch $RELAX_FILE"
       fi
     fi
 
@@ -472,7 +472,7 @@ ${COV_FAIL}[quality-gate] Agrega tests. Kill switch para este repo: touch $RELAX
     [ -z "$COV_BRANCH" ] && UNMEASURED="$UNMEASURED branch"
     [ -z "$COV_FUNC" ] && UNMEASURED="$UNMEASURED function"
     [ -n "$UNMEASURED" ] &&
-      echo "[quality-gate] [$LABEL] NO MEDIDO (el runner no lo reporta):$UNMEASURED — no lo cuentes como verde." >&2
+      echo "[quality-gate] [$LABEL] NOT MEASURED (the runner does not report it):$UNMEASURED — do not count it as green." >&2
 
   fi
 
@@ -496,16 +496,16 @@ ${COV_FAIL}[quality-gate] Agrega tests. Kill switch para este repo: touch $RELAX
     # tiene configurada, el lint de arriba ya fallo por ella y no hay nada que
     # duplicar aca. Si no la tiene, se avisa una vez.
     if ! (cd "$PROJECT_DIR" && rg -q 'complexity' .eslintrc* eslint.config.* 2>/dev/null); then
-      echo "[quality-gate] [$LABEL] NO MEDIDO: complejidad ciclomatica. Agrega la regla eslint:" >&2
+      echo "[quality-gate] [$LABEL] NOT MEASURED: cyclomatic complexity. Add the eslint rule:" >&2
       echo "[quality-gate]   'complexity': ['error', { max: $MAX_COMPLEXITY }]" >&2
     fi
   fi
 
   if [ -n "$COMPLEXITY_OVER" ]; then
     if [ "$RELAXED" = true ]; then
-      echo "[quality-gate] [$LABEL] complejidad sobre $MAX_COMPLEXITY ($RELAX_FILE presente, no bloquea)." >&2
+      echo "[quality-gate] [$LABEL] complexity over $MAX_COMPLEXITY ($RELAX_FILE present, not blocking)." >&2
     else
-      block "[$LABEL] hay funciones con complejidad ciclomatica > $MAX_COMPLEXITY. Extrae metodos." "$COMPLEXITY_OUTPUT"
+      block "[$LABEL] there are functions with cyclomatic complexity > $MAX_COMPLEXITY. Extract methods." "$COMPLEXITY_OUTPUT"
     fi
   fi
 done

--- a/config/claude/hooks/secret-detect.sh
+++ b/config/claude/hooks/secret-detect.sh
@@ -58,13 +58,13 @@ if [ "$blocked" -gt 0 ]; then
   {
     echo ""
     echo "========================================"
-    echo "  PROMPT BLOQUEADO: secret detectado"
+    echo "  PROMPT BLOCKED: secret detected"
     echo "========================================"
-    echo "Se detectaron $blocked patron(es) de API key, token o clave privada."
-    echo "El prompt NO se envio al modelo."
+    echo "Detected $blocked pattern(s) of API key, token or private key."
+    echo "The prompt was NOT sent to the model."
     echo ""
-    echo "Saca la credencial y reemplazala por un placeholder (\$API_KEY, <token>)."
-    echo "Si la credencial es real y ya se compartio en otro lado, ROTALA."
+    echo "Remove the credential and replace it with a placeholder (\$API_KEY, <token>)."
+    echo "If the credential is real and was already shared elsewhere, ROTATE IT."
     echo "========================================"
     echo ""
   } >&2
@@ -74,8 +74,8 @@ fi
 if [ "$warned" -gt 0 ]; then
   {
     echo ""
-    echo "[secret-detect] ATENCION: el prompt trae algo con forma de JWT."
-    echo "[secret-detect] Si es un token real, corta (Ctrl+C) y reemplazalo por <token>."
+    echo "[secret-detect] WARNING: the prompt contains something shaped like a JWT."
+    echo "[secret-detect] If it is a real token, abort (Ctrl+C) and replace it with <token>."
     echo ""
   } >&2
 fi

--- a/config/claude/hooks/stop-check-pending.sh
+++ b/config/claude/hooks/stop-check-pending.sh
@@ -24,9 +24,9 @@ fi
 : >"$MARKER"
 
 echo "" >&2
-echo "⚠️  CAMBIOS PENDIENTES en $PWD:" >&2
-[ -n "$UNSTAGED" ] && echo "   🔴 Archivos sin stage: $(echo "$UNSTAGED" | wc -l | tr -d ' ')" >&2
-[ -n "$STAGED" ] && echo "   🟡 Archivos staged (sin commit): $(echo "$STAGED" | wc -l | tr -d ' ')" >&2
-[ -n "$STASHES" ] && echo "   📦 Auto-save stashes pendientes: $(echo "$STASHES" | wc -l | tr -d ' ')" >&2
+echo "⚠️  PENDING CHANGES in $PWD:" >&2
+[ -n "$UNSTAGED" ] && echo "   🔴 Unstaged files: $(echo "$UNSTAGED" | wc -l | tr -d ' ')" >&2
+[ -n "$STAGED" ] && echo "   🟡 Staged files (not committed): $(echo "$STAGED" | wc -l | tr -d ' ')" >&2
+[ -n "$STASHES" ] && echo "   📦 Pending auto-save stashes: $(echo "$STASHES" | wc -l | tr -d ' ')" >&2
 echo "" >&2
 exit 0

--- a/config/claude/hooks/validate-safe-ops.sh
+++ b/config/claude/hooks/validate-safe-ops.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # Fallar cerrado evita que auto/bypassPermissions convierta la ausencia del
 # parser en una vía para ejecutar una operación que debía bloquearse.
 if ! command -v jq >/dev/null 2>&1; then
-  echo "[validate-safe-ops] jq no esta instalado: bloqueo preventivo; instalalo con: brew install jq" >&2
+  echo "[validate-safe-ops] jq is not installed: blocking preventively; install it with: brew install jq" >&2
   exit 2
 fi
 
@@ -125,15 +125,15 @@ ask() {
 
 # Pipe a bash (RCE classico)
 if echo "$NO_QUOTES_FULL" | grep -qE 'curl.*\|.*(bash|sh|zsh)'; then
-  deny "curl | bash bloqueado. Descarga el script, revisalo, y ejecutalo por separado."
+  deny "curl | bash blocked. Download the script, review it, and run it separately."
 fi
 if echo "$NO_QUOTES_FULL" | grep -qE 'wget.*-O\s*-\s*.*\|.*(bash|sh|zsh)'; then
-  deny "wget | bash bloqueado. Descarga el script, revisalo, y ejecutalo por separado."
+  deny "wget | bash blocked. Download the script, review it, and run it separately."
 fi
 
 # DROP TABLE via echo/printf pipe (patron multi-comando)
 if echo "$NO_QUOTES_FULL" | grep -qiE '(echo|printf|cat).*\bDROP\s+(TABLE|DATABASE|SCHEMA)\b.*\|'; then
-  deny "DROP TABLE via pipe bloqueado. Ejecuta manualmente si es intencional."
+  deny "DROP TABLE via pipe blocked. Run it manually if it is intentional."
 fi
 
 # Lectura de secretos por shell.
@@ -172,7 +172,7 @@ ENV_DUMP_FLAGS='(^|[|;&])[[:space:]]*(export[[:space:]]+-p|declare[[:space:]]+-x
 SENSITIVE_VAR='\$\{?[A-Za-z_][A-Za-z0-9_]*(_KEY|_SECRET|_TOKEN|_PASSWORD|_PASSWD|_CREDENTIALS?|_APIKEY)\b'
 
 if echo "$HAYSTACK" | grep -qE "$ENV_DUMP" || echo "$HAYSTACK" | grep -qE "$ENV_DUMP_FLAGS"; then
-  deny "Volcado del entorno bloqueado. 'env'/'printenv'/'export -p' imprimen TODAS las variables, incluidos los tokens que hoy tenes cargados. Si necesitas una variable puntual, nombrala; si necesitas saber si existe, usa: [ -n \"\${VAR:-}\" ] && echo definida."
+  deny "Environment dump blocked. 'env'/'printenv'/'export -p' print ALL variables, including the tokens currently loaded. If you need a specific variable, name it; if you need to know whether it exists, use: [ -n \"\${VAR:-}\" ] && echo defined."
 fi
 
 # IMPRIMIR un secreto se bloquea; USARLO no.
@@ -186,15 +186,15 @@ fi
 # matcheaba nada. La version sin comillas se bloqueaba y la peligrosa pasaba.
 PRINTERS='(echo|printf|print|cat|tee|head|tail|write|logger|say)'
 if echo "$COMMAND" | grep -qE "\b${PRINTERS}\b[^|;&]*${SENSITIVE_VAR}"; then
-  deny "Imprimir una variable con nombre de secreto bloqueado (*_KEY, *_SECRET, *_TOKEN, *_PASSWORD, *_CREDENTIAL). Va a stdout, al transcript y a los logs. Pasala directo al comando que la necesita — 'curl -H \"auth: \$TOKEN\"' esta permitido — o comproba solo si existe: [ -n \"\${VAR:-}\" ] && echo definida."
+  deny "Printing a secret-named variable is blocked (*_KEY, *_SECRET, *_TOKEN, *_PASSWORD, *_CREDENTIAL). It goes to stdout, to the transcript and to the logs. Pass it straight to the command that needs it — 'curl -H \"auth: \$TOKEN\"' is allowed — or only check whether it exists: [ -n \"\${VAR:-}\" ] && echo defined."
 fi
 
 if ! echo "$HAYSTACK" | grep -qE "$IS_TEMPLATE"; then
   if echo "$HAYSTACK" | grep -qE "\b(cat|bat|head|tail|less|more|nl|od|xxd|strings|base64|cp|mv|rsync|scp|open|source|\.)\b[^|;&]*${SECRET_ARG}"; then
-    deny "Lectura de secretos por shell bloqueada (.env, credentials.json, claves privadas, certs). El deny de settings.json solo cubre el tool Read; esto cierra el mismo agujero por Bash. Si necesitas una variable, leela del entorno, no del archivo."
+    deny "Reading secrets through the shell is blocked (.env, credentials.json, private keys, certs). The settings.json deny only covers the Read tool; this closes the same hole through Bash. If you need a variable, read it from the environment, not from the file."
   fi
   if echo "$HAYSTACK" | grep -qE "\b(rg|grep|ag|ack|awk|sed|sd)\b[^|;&]*${SECRET_ARG}"; then
-    deny "Grep/sed sobre un archivo de secretos bloqueado. Usa el nombre de la variable desde el entorno, no el contenido del archivo."
+    deny "Grep/sed over a secrets file is blocked. Use the variable name from the environment, not the file contents."
   fi
 fi
 
@@ -291,20 +291,20 @@ if echo "$ORM_HAYSTACK" | grep -qEi "$ORM_SCHEMA" || echo "$ORM_HAYSTACK" | grep
 
   # 1. Verbo destructivo sin vuelta atras.
   if echo "$ORM_HAYSTACK" | grep -qEi "$ORM_DESTRUCTIVE" || echo "$ORM_HAYSTACK" | grep -qEi "$ARTISAN_RAILS"; then
-    deny "Operacion de esquema destructiva bloqueada. Estos comandos dropean o vacian tablas aunque el nombre no lo diga. Antes de correrlo a mano: (1) confirma a que base apunta la conexion, (2) verifica que exista un backup restaurable, (3) declara el blast radius al usuario. Ver rules/common/destructive-operations.md."
+    deny "Destructive schema operation blocked. These commands drop or empty tables even when the name does not say so. Before running it by hand: (1) confirm which database the connection points to, (2) verify a restorable backup exists, (3) declare the blast radius to the user. See rules/common/destructive-operations.md."
   fi
 
   # 2. Destino remoto explicito en cualquier operacion de esquema.
   if echo "$ORM_HAYSTACK" | grep -qEi "$REMOTE_DSN"; then
     if ! echo "$ORM_HAYSTACK" | grep -qEi "://[^[:space:]@]*(@)?${LOCAL_HOST}"; then
-      deny "Operacion de esquema apuntando a un host REMOTO. Asi se vacio una base de produccion: el comando parecia inofensivo y la URL apuntaba a prod. Corre el esquema contra local, o pedile al usuario que lo ejecute el mismo contra ese host."
+      deny "Schema operation targeting a REMOTE host. This is how a production database got wiped: the command looked harmless and the URL pointed at prod. Run the schema against local, or ask the user to run it themselves against that host."
     fi
   fi
 
   # 3. Destino en una variable sin resolver: no se puede saber a donde apunta.
   # Este es EXACTAMENTE el caso del incidente ($DATABASE_URL_UNPOOLED).
   if echo "$ORM_HAYSTACK" | grep -qE '(--[a-z-]*(database-)?url[= ]|DATABASE_URL[A-Z_]*=)[^[:space:]]*\$'; then
-    deny "El destino de esta operacion de esquema viene de una variable sin resolver, asi que ni vos ni el hook saben a que base apunta. Ese es el caso exacto que vacio una Supabase de produccion: --shadow-database-url recibia una variable que apuntaba a prod, y la shadow database se resetea por diseño. VERIFICA primero a donde resuelve (sin imprimir credenciales) y decilo antes de correr nada."
+    deny "The target of this schema operation comes from an unresolved variable, so neither you nor the hook knows which database it points to. That is the exact case that wiped a production Supabase: --shadow-database-url received a variable pointing at prod, and the shadow database is reset by design. VERIFY first where it resolves to (without printing credentials) and say so before running anything."
   fi
 fi
 
@@ -315,9 +315,9 @@ if echo "$NO_QUOTES_FULL" | grep -qE "$RM_RECURSIVE"; then
   # Solo el objetivo decide el nivel. Borrar la raiz o el home no se negocia;
   # borrar un build o un directorio temporal es trabajo normal.
   if echo "$NO_QUOTES_FULL" | grep -qE '\brm\s+(-[a-zA-Z]+\s+)+(/|/\*|~|~/|~/\*|\$HOME|\$HOME/|\$HOME/\*)(\s|$|;|&)'; then
-    deny "rm -rf sobre la raiz o el home bloqueado. Es irreversible y no hay razon legitima para correrlo desde una sesion de agente."
+    deny "rm -rf over the root or the home directory is blocked. It is irreversible and there is no legitimate reason to run it from an agent session."
   fi
-  ask "rm -rf es irreversible. Revisa el path exacto antes de aprobar."
+  ask "rm -rf is irreversible. Review the exact path before approving."
 fi
 
 # Borrar un test por Bash. protect-tests.sh solo ve Edit|Write|NotebookEdit, y la
@@ -331,11 +331,11 @@ fi
 # que `rm test_login.py` (el argumento pegado al comando) se escapaba entero.
 RM_TEST='\brm\b[^|;&]*((\.|_)(test|spec)\.|[[:space:]/]test_|[[:space:]/](tests?|specs?|__tests__|__snapshots__|features|e2e)/|(Test|Tests|Spec)\.(java|kt|cs|scala|php|swift)|\.(snap|ambr|feature)([[:space:]]|$))'
 if echo "$NO_QUOTES_FULL" | grep -qE "$RM_TEST"; then
-  ask "Estas borrando cobertura de tests. Hard Rule 8: un test no se elimina para que el codigo pase. Si el requisito cambio de verdad, deci que test es, por que, y que queda cubierto despues."
+  ask "You are deleting test coverage. Hard Rule 8: a test is not removed to make the code pass. If the requirement genuinely changed, state which test, why, and what stays covered afterwards."
 fi
 
 if echo "$NO_QUOTES_FULL" | grep -qE '\bchmod\s+(-R\s+)?777\b'; then
-  ask "chmod 777 deja el archivo escribible por cualquiera. Aprobalo solo si es un directorio descartable; si no, usa 644/755/700."
+  ask "chmod 777 makes the file writable by anyone. Approve it only for a throwaway directory; otherwise use 644/755/700."
 fi
 
 # === BINARY-SPECIFIC ===
@@ -355,32 +355,32 @@ check_segment() {
 
   case "$binary" in
     sudo | doas)
-      deny "sudo bloqueado. Ejecuta sin privilegios elevados."
+      deny "sudo blocked. Run without elevated privileges."
       ;;
     git)
       # --force($|[^-]) = --force al final o seguido de espacio (no --force-with-lease)
       if echo "$segment" | grep -qE '\bpush\b.*--force($|[^-])'; then
-        deny "git push --force bloqueado. Usa --force-with-lease si es necesario."
+        deny "git push --force blocked. Use --force-with-lease if it is necessary."
       fi
       if echo "$segment" | grep -qE '\bpush\b.*(\s-f\b|^-f\b)'; then
-        deny "git push -f bloqueado. Usa --force-with-lease si es necesario."
+        deny "git push -f blocked. Use --force-with-lease if it is necessary."
       fi
       # Un refspec con "+" delante es un force push sin la palabra force:
       # `git push origin +main` sobrescribe el remoto igual que --force. Sin
       # esta linea, la regla de arriba se esquiva escribiendo el mismo efecto
       # de otra forma, que es el modo de falla de validar un CLI por su texto.
       if echo "$segment" | grep -qE '\bpush\b.*[[:space:]]\+[A-Za-z0-9_./-]+(:|$|[[:space:]])'; then
-        deny "git push con refspec '+' es un force push. Usa --force-with-lease si es necesario."
+        deny "git push with a '+' refspec is a force push. Use --force-with-lease if it is necessary."
       fi
       if echo "$segment" | grep -qE '\breset\s+.*--hard(\s|$)'; then
-        deny "git reset --hard bloqueado. Usa git stash o git checkout -- <file> para descartes selectivos."
+        deny "git reset --hard blocked. Use git stash or git checkout -- <file> for selective discards."
       fi
       # Descartan trabajo no commiteado, pero son parte del dia a dia: decide el usuario.
       if echo "$segment" | grep -qE '\bclean\b.*-[a-zA-Z]*[fdx]'; then
-        ask "git clean borra archivos sin trackear de forma irreversible. Revisa 'git clean -n' antes de aprobar."
+        ask "git clean deletes untracked files irreversibly. Review 'git clean -n' before approving."
       fi
       if echo "$segment" | grep -qE '\bcheckout\b.*(\s-f\b|--force\b)'; then
-        ask "git checkout -f descarta cambios locales sin backup. Aprobalo solo si sabes que no perdes nada."
+        ask "git checkout -f discards local changes with no backup. Approve it only if you know nothing is lost."
       fi
       ;;
     npm)
@@ -388,33 +388,33 @@ check_segment() {
       # Las tres formas son el mismo install global: npm acepta -g, --global y
       # --location=global. Validar solo la corta deja las otras dos abiertas.
       if echo "$segment" | grep -qE '\b(install|i)\b.*(\s-g(\s|$)|^-g(\s|$)|--global(\s|$)|--location=global(\s|$))'; then
-        deny "npm install global bloqueado. Usa npx para herramientas one-shot."
+        deny "npm global install blocked. Use npx for one-shot tools."
       fi
       ;;
     pip | pip3)
       if echo "$segment" | grep -qE '\binstall\b.*--break-system-packages'; then
-        deny "pip install --break-system-packages bloqueado. By-passea la proteccion del venv. Usa un venv o uv."
+        deny "pip install --break-system-packages blocked. It bypasses the venv protection. Use a venv or uv."
       fi
       ;;
     kubectl)
       if echo "$segment" | grep -qE '^\s*kubectl\s+delete\b'; then
-        deny "kubectl delete bloqueado. Operacion destructiva en el cluster."
+        deny "kubectl delete blocked. Destructive operation on the cluster."
       fi
       ;;
     helm)
       if echo "$segment" | grep -qE '^\s*helm\s+(uninstall|delete)\b'; then
-        deny "helm uninstall/delete bloqueado. Operacion destructiva en el cluster."
+        deny "helm uninstall/delete blocked. Destructive operation on the cluster."
       fi
       ;;
     terraform)
       if echo "$segment" | grep -qE '\bterraform\s+destroy\b|\bterraform\s+apply\b.*-auto-approve'; then
-        deny "terraform destroy/apply -auto-approve bloqueado. Infraestructura como codigo requiere revision manual."
+        deny "terraform destroy/apply -auto-approve blocked. Infrastructure as code requires manual review."
       fi
       ;;
     mysql | psql | sqlite3 | mongo | mongosh | redis-cli | mariadb | cockroach | sqlplus | duckdb | clickhouse-client | bq | snowsql | mysqlsh)
       # Sobre el comando original (con quotes): el DROP suele ir dentro de -e "..." o -c "..."
       if echo "$COMMAND" | grep -qiE '\bDROP\s+(TABLE|DATABASE|SCHEMA)\b'; then
-        deny "DROP TABLE/DATABASE bloqueado. Ejecuta manualmente si es intencional."
+        deny "DROP TABLE/DATABASE blocked. Run it manually if it is intentional."
       fi
       ;;
     dd)
@@ -422,11 +422,11 @@ check_segment() {
       # sin necesitar if=. Validar solo la entrada dejaba pasar exactamente la
       # mitad peligrosa del comando.
       if echo "$segment" | grep -qE '\b(if|of)='; then
-        deny "dd bloqueado. Operacion de bajo nivel peligrosa."
+        deny "dd blocked. Dangerous low-level operation."
       fi
       ;;
     mkfs | mkfs.* | newfs | newfs_msdos)
-      deny "mkfs/newfs bloqueado. Formateo de filesystem es irreversible sin backup."
+      deny "mkfs/newfs blocked. Formatting a filesystem is irreversible without a backup."
       ;;
   esac
 }

--- a/config/claude/rules/common/context-management.md
+++ b/config/claude/rules/common/context-management.md
@@ -38,12 +38,12 @@ Every `mem_save` and every handoff must preserve:
 ## Anti-pattern: action-only summary
 
 ```text
-// MAL — truncacion glorificada. El modelo pierde el reasoning.
+// BAD — glorified truncation. The model loses the reasoning.
 "Fixed auth middleware bug. Added tests. All green."
 ```
 
 ```text
-// BIEN — preserva el chain of thought.
+// GOOD — preserves the chain of thought.
 "Auth middleware bug: token expiry used < instead of <= at L42.
  Rejected: timezone offset (tz data was correct), JWT lib bug (clean decode logs).
  Fix: changed operator + edge test at midnight boundary.

--- a/config/claude/rules/common/testing.md
+++ b/config/claude/rules/common/testing.md
@@ -68,7 +68,7 @@ Three questions. Any "no" means you are not finished:
 
 - **Documentation** (README, comments, ADRs).
 - **Static config** that does not affect behavior (format, style, metadata).
-- **CI/infra config** (workflows, dependabot, deploy YAML, lockfiles): no se testea con unit tests; se valida con linters (actionlint) y con la corrida de CI misma.
+- **CI/infra config** (workflows, dependabot, deploy YAML, lockfiles): not covered by unit tests; validated with linters (actionlint) and by the CI run itself.
 - **Generated code** (ORM models, protobuf, OpenAPI stubs).
 - **Tests of tests** (do not test mocks, fixtures, or test helpers).
 

--- a/config/claude/scripts/check-skill-deps.sh
+++ b/config/claude/scripts/check-skill-deps.sh
@@ -14,18 +14,18 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LOCK="$DIR/skills-lock.json"
 
 if ! command -v jq >/dev/null 2>&1; then
-  echo "check-skill-deps: jq no esta instalado; no puedo leer skills-lock.json" >&2
+  echo "check-skill-deps: jq is not installed; cannot read skills-lock.json" >&2
   exit 1
 fi
 if [ ! -f "$LOCK" ]; then
-  echo "check-skill-deps: falta $LOCK" >&2
+  echo "check-skill-deps: $LOCK is missing" >&2
   exit 1
 fi
 
 missing=0
 report() {
   missing=$((missing + 1))
-  echo "  FALTA  $1  (skill: $2)"
+  echo "  MISSING  $1  (skill: $2)"
 }
 
 # Los nombres declarativos suelen coincidir con el import en el lock activo.
@@ -39,7 +39,7 @@ sys_binary() {
   echo "$1"
 }
 
-echo "Verificando dependencias de skills..."
+echo "Checking skill dependencies..."
 
 # Version minima de python por skill. No asumas que el primer python3 del PATH
 # funciona: en macOS un shim pyenv roto puede abortar el proceso antes de
@@ -68,12 +68,12 @@ PY_VERSION="0.0"
 if [ -n "$PYTHON_BIN" ]; then
   PY_VERSION=$("$PYTHON_BIN" -c 'import sys; print(".".join(map(str, sys.version_info[:2])))' 2>/dev/null || echo "0.0")
 fi
-echo "  python $PY_VERSION via ${PYTHON_BIN:-no disponible}"
+echo "  python $PY_VERSION via ${PYTHON_BIN:-unavailable}"
 while IFS=$'\t' read -r skill min_py; do
   [ -z "$skill" ] || [ -z "$min_py" ] && continue
   if [ "$(printf '%s\n' "$min_py" "$PY_VERSION" | sort -V | head -1)" != "$min_py" ]; then
     missing=$((missing + 1))
-    echo "  FALTA  python $min_py+ (system python3 es $PY_VERSION)  (skill: $skill)"
+    echo "  MISSING  python $min_py+ (system python3 is $PY_VERSION)  (skill: $skill)"
   fi
 done < <(jq -r '.skills | to_entries[] | select(.value.python_version) | [.key, .value.python_version] | @tsv' "$LOCK")
 
@@ -92,7 +92,7 @@ while IFS=$'\t' read -r skill kind dep; do
       ;;
     node)
       # Las deps de node se instalan por proyecto, no global: solo se informan.
-      [ "$QUIET" -eq 1 ] || echo "  info   node: $dep se instala por proyecto (skill: $skill)"
+      [ "$QUIET" -eq 1 ] || echo "  info   node: $dep is installed per project (skill: $skill)"
       ;;
   esac
 done < <(jq -r '.skills | to_entries[] | .key as $s | .value.deps // {} | to_entries[] | .key as $k | .value[] | [$s, $k, .] | @tsv' "$LOCK")
@@ -111,7 +111,7 @@ while IFS= read -r package_json; do
     dep_path="$skill_dir/node_modules/$dep"
     if [ ! -e "$dep_path" ]; then
       local_node_info=$((local_node_info + 1))
-      [ "$QUIET" -eq 1 ] || echo "  info   node local: $dep no esta provisionado (skill: $skill_name; ejecutar npm install dentro de la skill cuando aplique)"
+      [ "$QUIET" -eq 1 ] || echo "  info   local node: $dep is not provisioned (skill: $skill_name; run npm install inside the skill when it applies)"
     fi
   done < <(jq -r '.dependencies // {} | keys[]' "$package_json")
 done < <(find "$SKILLS_ROOT_FOR_PACKAGES" -mindepth 2 -maxdepth 2 -name package.json -type f -print)
@@ -125,7 +125,7 @@ while IFS=$'\t' read -r skill dep; do
   [ -z "$skill" ] || [ -z "$dep" ] && continue
   if [ -z "$PYTHON_BIN" ] || ! "$PYTHON_BIN" -c "import $dep" >/dev/null 2>&1; then
     optional_info=$((optional_info + 1))
-    [ "$QUIET" -eq 1 ] || echo "  info   python opcional: $dep no esta provisionado (skill: $skill; resolver con uv --with cuando aplique)"
+    [ "$QUIET" -eq 1 ] || echo "  info   optional python: $dep is not provisioned (skill: $skill; resolve with uv --with when it applies)"
   fi
 done < <(jq -r '.skills | to_entries[] | .key as $s | .value.optional_python // [] | .[] | [$s, .] | @tsv' "$LOCK")
 
@@ -133,7 +133,7 @@ while IFS=$'\t' read -r skill dep; do
   [ -z "$skill" ] || [ -z "$dep" ] && continue
   if ! command -v "$dep" >/dev/null 2>&1; then
     optional_info=$((optional_info + 1))
-    [ "$QUIET" -eq 1 ] || echo "  info   binario opcional: $dep no esta provisionado (skill: $skill; instalar solo bajo demanda)"
+    [ "$QUIET" -eq 1 ] || echo "  info   optional binary: $dep is not provisioned (skill: $skill; install on demand only)"
   fi
 done < <(jq -r '.skills | to_entries[] | .key as $s | .value.optional_system // [] | .[] | [$s, .] | @tsv' "$LOCK")
 
@@ -145,25 +145,25 @@ if [ -d "$SKILLS_ROOT" ]; then
   invalid=0
   while IFS= read -r skill_file; do
     if ! grep -q '^name:' "$skill_file" || ! grep -q '^description:' "$skill_file"; then
-      echo "  invalid  frontmatter incompleto: ${skill_file#"$SKILLS_ROOT/"}"
+      echo "  invalid  incomplete frontmatter: ${skill_file#"$SKILLS_ROOT/"}"
       invalid=$((invalid + 1))
     fi
   done < <(find "$SKILLS_ROOT" -name SKILL.md -maxdepth 2 -type f)
   if [ "$invalid" -gt 0 ]; then
-    echo "$invalid skill(s) con frontmatter invalido: sin 'name:' y 'description:' el harness no las carga."
+    echo "$invalid skill(s) with invalid frontmatter: without 'name:' and 'description:' the harness does not load them."
     missing=$((missing + invalid))
   fi
 fi
 
 if [ "$missing" -eq 0 ]; then
   if [ "$local_node_info" -gt 0 ] || [ "$optional_info" -gt 0 ]; then
-    echo "OK — dependencias requeridas del lock y frontmatter validos; hay capacidades bajo demanda informadas."
+    echo "OK — required lock dependencies and frontmatter are valid; on-demand capabilities are reported above."
   else
-    echo "OK — dependencias presentes y frontmatter de skills valido."
+    echo "OK — dependencies present and skill frontmatter valid."
   fi
   exit 0
 fi
 
 echo
-echo "$missing dependencia(s) faltante(s). No se instala nada automaticamente; revisa el entorno del proyecto o reporta la limitacion del host."
+echo "$missing missing dependency(ies). Nothing is installed automatically; check the project environment or report the host limitation."
 exit 1

--- a/config/claude/scripts/rdd.sh
+++ b/config/claude/scripts/rdd.sh
@@ -29,7 +29,7 @@ die() {
   exit 1
 }
 
-repo_root() { git rev-parse --show-toplevel 2>/dev/null || die "no es un repo git"; }
+repo_root() { git rev-parse --show-toplevel 2>/dev/null || die "not a git repo"; }
 
 sha() {
   if command -v sha256sum >/dev/null 2>&1; then sha256sum | cut -d' ' -f1; else shasum -a 256 | cut -d' ' -f1; fi
@@ -53,8 +53,8 @@ json_get() { grep -o "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$1" 2>/dev/nul
 cmd_freeze() {
   local root
   root=$(repo_root)
-  cd "$root" || die "no pude entrar a $root"
-  git diff --cached --quiet && die "no hay nada staged que congelar"
+  cd "$root" || die "could not enter $root"
+  git diff --cached --quiet && die "there is nothing staged to freeze"
 
   local max_fix="${1:-40}"
   mkdir -p "$STATE_DIR"
@@ -73,20 +73,20 @@ cmd_freeze() {
 }
 EOF
   rm -f "$RECEIPT"
-  echo "candidato congelado"
+  echo "candidate frozen"
   echo "  hash          $h"
-  echo "  archivos      $(git diff --cached --name-only | wc -l | tr -d ' ')"
-  echo "  lineas        $n"
-  echo "  techo de fix  $max_fix lineas"
+  echo "  files         $(git diff --cached --name-only | wc -l | tr -d ' ')"
+  echo "  lines         $n"
+  echo "  fix ceiling   $max_fix lines"
   echo
-  echo "Revisa AHORA sobre estos bytes. Si tocas algo, el hash cambia y el recibo no va a validar."
+  echo "Review those bytes NOW. If you touch anything, the hash changes and the receipt will not validate."
 }
 
 cmd_receipt() {
   local root
   root=$(repo_root)
-  cd "$root" || die "no pude entrar a $root"
-  [ -f "$CANDIDATE" ] || die "no hay candidato congelado. Corre: rdd freeze"
+  cd "$root" || die "could not enter $root"
+  [ -f "$CANDIDATE" ] || die "there is no frozen candidate. Run: rdd freeze"
 
   local frozen now
   frozen=$(json_get "$CANDIDATE" hash)
@@ -103,15 +103,15 @@ cmd_receipt() {
   now_lines=$(staged_line_count)
   delta=$((now_lines > frozen_lines ? now_lines - frozen_lines : frozen_lines - now_lines))
   if [ "$delta" -gt "$max" ]; then
-    die "la correccion movio $delta lineas y el techo es $max. Eso ya no es un fix acotado: achicalo, o congela un candidato nuevo a proposito."
+    die "the correction moved $delta lines and the ceiling is $max. That is no longer a bounded fix: shrink it, or freeze a new candidate on purpose."
   fi
 
   if [ "$frozen" != "$now" ]; then
-    echo "rdd: los bytes cambiaron desde el freeze." >&2
-    echo "  congelado: $frozen" >&2
-    echo "  ahora:     $now" >&2
-    echo "  El fix entra en el techo, pero el review cubrio otro contenido." >&2
-    echo "  Volve a congelar y revisa el delta antes de pedir el recibo." >&2
+    echo "rdd: the bytes changed since the freeze." >&2
+    echo "  frozen: $frozen" >&2
+    echo "  now:    $now" >&2
+    echo "  The fix fits under the ceiling, but the review covered other content." >&2
+    echo "  Freeze again and review the delta before asking for the receipt." >&2
     exit 1
   fi
 
@@ -120,18 +120,18 @@ cmd_receipt() {
   # ponia el `true`, no los tests. Eso rompia la propiedad que justifica RDD
   # entera — "no se emite recibo salvo que la evidencia salga 0".
   # Como argv, `||` y `true` llegan como argumentos literales a npm y falla.
-  [ "$#" -gt 0 ] || die "falta la evidencia. Uso: rdd receipt <comando de tests>  (ej: rdd receipt npm test)"
+  [ "$#" -gt 0 ] || die "the evidence is missing. Usage: rdd receipt <test command>  (e.g. rdd receipt npm test)"
 
   # Los metacaracteres van literales a proposito: se buscan como texto, no se expanden.
   # shellcheck disable=SC2016
   case "$*" in
     *'|'* | *';'* | *'&'* | *'$('* | *'`'*)
-      die "la evidencia trae metacaracteres de shell. Pasala como argv (rdd receipt npm test), no como string: un operador ahi puede fabricar el exit 0 que el recibo dice haber verificado."
+      die "the evidence contains shell metacharacters. Pass it as argv (rdd receipt npm test), not as a string: an operator there can fabricate the exit 0 the receipt claims to have verified."
       ;;
   esac
 
   local evidence_cmd="$*"
-  echo "corriendo evidencia: $evidence_cmd"
+  echo "running evidence: $evidence_cmd"
   local out rc
   out=$("$@" 2>&1)
   rc=$?
@@ -139,7 +139,7 @@ cmd_receipt() {
 
   if [ "$rc" -ne 0 ]; then
     echo
-    die "la evidencia fallo (exit $rc). Sin evidencia verde no hay recibo."
+    die "the evidence failed (exit $rc). No green evidence, no receipt."
   fi
 
   mkdir -p "$STATE_DIR"
@@ -153,7 +153,7 @@ cmd_receipt() {
 }
 EOF
   echo
-  echo "RECIBO EMITIDO — commit autorizado para el hash $frozen"
+  echo "RECEIPT ISSUED — commit authorized for hash $frozen"
 }
 
 # Usado por quality-gate.sh. Silencioso; el exit code es el contrato.
@@ -173,20 +173,20 @@ cmd_verify() {
 cmd_status() {
   local root
   root=$(repo_root)
-  cd "$root" || die "no pude entrar a $root"
-  if [ -f "$SWITCH" ]; then echo "RDD: ENCENDIDO (bloquea commits sin recibo)"; else echo "RDD: apagado (quality-gate solo avisa)"; fi
+  cd "$root" || die "could not enter $root"
+  if [ -f "$SWITCH" ]; then echo "RDD: ON (blocks commits without a receipt)"; else echo "RDD: off (quality-gate only warns)"; fi
   if [ -f "$CANDIDATE" ]; then
     local frozen
     frozen=$(json_get "$CANDIDATE" hash)
-    echo "candidato: $frozen"
-    [ "$frozen" = "$(candidate_hash)" ] && echo "  los bytes staged COINCIDEN" || echo "  los bytes staged CAMBIARON desde el freeze"
+    echo "candidate: $frozen"
+    [ "$frozen" = "$(candidate_hash)" ] && echo "  the staged bytes MATCH" || echo "  the staged bytes CHANGED since the freeze"
   else
-    echo "candidato: ninguno"
+    echo "candidate: none"
   fi
   if [ -f "$RECEIPT" ]; then
-    cmd_verify && echo "recibo: VALIDO" || echo "recibo: presente pero para otros bytes"
+    cmd_verify && echo "receipt: VALID" || echo "receipt: present but for other bytes"
   else
-    echo "recibo: ninguno"
+    echo "receipt: none"
   fi
 }
 
@@ -195,14 +195,14 @@ cmd_on() {
   root=$(repo_root)
   mkdir -p "$root/$STATE_DIR" && touch "$root/$SWITCH"
   grep -qxF "$STATE_DIR/" "$root/.gitignore" 2>/dev/null || printf '%s/\n' "$STATE_DIR" >>"$root/.gitignore"
-  echo "RDD encendido en $root. .gitignore actualizado."
+  echo "RDD turned on in $root. .gitignore updated."
 }
 
 cmd_off() {
   local root
   root=$(repo_root)
   rm -f "$root/$SWITCH"
-  echo "RDD apagado en $root. Los commits ya no requieren recibo."
+  echo "RDD turned off in $root. Commits no longer require a receipt."
 }
 
 case "${1:-}" in
@@ -216,13 +216,13 @@ case "${1:-}" in
     cat <<'EOF'
 rdd.sh — Receipt Driven Development
 
-  rdd freeze [max_fix_lines]   congela los bytes staged (default: techo 40)
-  rdd receipt <cmd tests>      corre la evidencia y emite el recibo (argv, sin comillas)
-  rdd verify                   exit 0 autorizado / 1 sin recibo / 2 otros bytes
-  rdd status                   estado actual
-  rdd on | rdd off             kill switch por repo
+  rdd freeze [max_fix_lines]   freeze the staged bytes (default: ceiling 40)
+  rdd receipt <test cmd>       run the evidence and issue the receipt (argv, unquoted)
+  rdd verify                   exit 0 authorized / 1 no receipt / 2 other bytes
+  rdd status                   current state
+  rdd on | rdd off             per-repo kill switch
 
-La regla: sin recibo atado a los bytes exactos, no hay commit.
+The rule: without a receipt bound to the exact bytes, there is no commit.
 EOF
     exit 2
     ;;

--- a/config/claude/scripts/validate.sh
+++ b/config/claude/scripts/validate.sh
@@ -29,7 +29,7 @@ SUITES=(
 SKIPPED=0
 for suite in "${SUITES[@]}"; do
   if [ ! -f "$suite" ]; then
-    printf '== %s no presente (suite local)\n' "$suite"
+    printf '== %s not present (local suite)\n' "$suite"
     SKIPPED=$((SKIPPED + 1))
     continue
   fi
@@ -37,11 +37,11 @@ for suite in "${SUITES[@]}"; do
   bash "$suite" >/dev/null
 done
 
-printf '== manifiestos JSON\n'
+printf '== JSON manifests\n'
 jq empty config/claude/settings.json
 jq empty config/claude/skills-lock.json
 
-printf '== dependencias de skills\n'
+printf '== skill dependencies\n'
 bash config/claude/scripts/check-skill-deps.sh >/dev/null
 
 # La etapa de linting solo corre si el binario esta disponible: en un host sin
@@ -60,19 +60,19 @@ if command -v shellcheck >/dev/null 2>&1; then
   # arbol no es un repo git: ahi la lista no es "cero scripts que pasan", es
   # una etapa que no se pudo armar.
   if [ ${#SCRIPTS[@]} -eq 0 ]; then
-    printf '== linting sin lista de archivos (fuera de un repo git)\n'
+    printf '== linting with no file list (outside a git repo)\n'
     SKIPPED=$((SKIPPED + 1))
   else
     printf '== linting\n'
     shellcheck -S warning "${SCRIPTS[@]}"
   fi
 else
-  printf '== linting no disponible (shellcheck ausente)\n'
+  printf '== linting unavailable (shellcheck absent)\n'
   SKIPPED=$((SKIPPED + 1))
 fi
 
 if [ "$SKIPPED" -gt 0 ]; then
-  printf 'CONFIG VALIDA — %s etapa(s) omitida(s), ninguna fallo\n' "$SKIPPED"
+  printf 'CONFIG VALID — %s stage(s) skipped, none failed\n' "$SKIPPED"
 else
-  printf 'TODO VERDE\n'
+  printf 'ALL GREEN\n'
 fi

--- a/config/claude/skills/cavecrew/SKILL.md
+++ b/config/claude/skills/cavecrew/SKILL.md
@@ -1,62 +1,62 @@
 ---
 name: cavecrew
-description: Protocolo de delegación a subagentes. Los subagentes escriben resultados a archivos y devuelven SOLO el path, nunca contenido verbatim por chat.
+description: Subagent delegation protocol. Subagents write results to files and return ONLY the path, never verbatim content through chat.
 ---
 
-## Protocolo de delegación
+## Delegation protocol
 
-Complementa la regla ANTI-TELEPHONE de CLAUDE.md con la convención de archivos y el template de delegación.
+Complements the ANTI-TELEPHONE rule in CLAUDE.md with the file convention and the delegation template.
 
-### Cuándo delegar
+### When to delegate
 
-- Exploración amplia del codebase (>3 lecturas de archivos)
-- Búsquedas en muchos archivos
-- Tareas de investigación en paralelo
-- Operaciones context-heavy que inflarían el contexto principal
+- Broad codebase exploration (>3 file reads)
+- Searches across many files
+- Parallel research tasks
+- Context-heavy operations that would bloat the main context
 
-### Reglas
+### Rules
 
-1. **Los subagentes escriben resultados a archivos.** Devuelven SOLO el path.
-2. **Nunca pasar contenido verbatim por chat.** El chat corrompe la señal; los archivos sobreviven a la compactación.
-3. **Si un subagente no te da un path, exigíselo.**
-4. **El agente principal lee el archivo cuando lo necesita.** No antes.
+1. **Subagents write results to files.** They return ONLY the path.
+2. **Never pass verbatim content through chat.** Chat corrupts the signal; files survive compaction.
+3. **If a subagent does not give you a path, demand one.**
+4. **The main agent reads the file when it needs it.** Not before.
 
-### Convención de archivos de salida
+### Output file convention
 
 ```
-/tmp/cavecrew/<nombre-tarea>-result.md
+/tmp/cavecrew/<task-name>-result.md
 ```
 
-### Tipos de subagente (Claude)
+### Subagent types (Claude)
 
-| Tipo | Uso |
+| Type | Use |
 |------|-----|
-| `explore` | Exploración de codebase, encontrar patrones, entender arquitectura |
-| `code-reviewer` | Revisión de diffs, análisis de seguridad |
-| `debugger` | Root cause analysis, investigación de errores |
-| `general` | Research, búsqueda de documentación, tareas multi-paso |
-| `security-auditor` | Auditorías de auth, permisos, secretos |
+| `explore` | Codebase exploration, finding patterns, understanding architecture |
+| `code-reviewer` | Diff review, security analysis |
+| `debugger` | Root cause analysis, error investigation |
+| `general` | Research, documentation lookup, multi-step tasks |
+| `security-auditor` | Auth, permission and secret audits |
 
-### Template de delegación
+### Delegation template
 
-Al delegar una tarea, incluí:
-1. Objetivo claro
-2. Scope (qué archivos/dirs buscar)
-3. Formato de salida esperado (path del archivo con resultados)
-4. Constraints (límite de tiempo, profundidad)
+When delegating a task, include:
+1. A clear objective
+2. Scope (which files/dirs to search)
+3. Expected output format (path of the results file)
+4. Constraints (time limit, depth)
 
-### Ejemplo de delegación
+### Delegation example
 
 ```
-Tarea: Encontrar todos los endpoints que aceptan input de usuario sin validación.
-Scope: src/routes/ y src/controllers/
-Output: Escribir hallazgos en /tmp/cavecrew/validation-audit-result.md
-Formato: Tabla con archivo, endpoint, parámetro, estado de validación actual
+Task: Find every endpoint that accepts user input without validation.
+Scope: src/routes/ and src/controllers/
+Output: Write findings to /tmp/cavecrew/validation-audit-result.md
+Format: Table with file, endpoint, parameter, current validation state
 ```
 
 ### Anti-patterns
 
-- No delegues tareas triviales (lectura de un solo archivo, grep simple).
-- No delegues y después hagas la misma búsqueda vos.
-- No aceptes resultados inline. Exigí siempre un path de archivo.
-- No delegues si ya tenés la respuesta en contexto.
+- Do not delegate trivial tasks (single file read, simple grep).
+- Do not delegate and then run the same search yourself.
+- Do not accept inline results. Always demand a file path.
+- Do not delegate if you already have the answer in context.

--- a/config/claude/skills/code-review/SKILL.md
+++ b/config/claude/skills/code-review/SKILL.md
@@ -44,12 +44,12 @@ Review in this order. Each dimension is an independent pass:
 - No commented-out code or dead code.
 - Testability: can this be tested easily?
 
-### 5. Estructura y diseño
-- **Regla 1k líneas**: un PR no debería empujar un archivo de <1k a >1k líneas sin justificación fuerte. Si lo cruza, proponer descomponer primero.
-- **Anti-spaghetti growth**: nuevos ad-hoc conditionals, scattered special cases o one-off branches en flows no relacionados = flag de diseño, no nit.
-- **Simplificación radical**: si el comportamiento se puede mantener con menos conceptos, branches o capas, buscar ese path. Preferir el refactor que BORRA complejidad, no que la mueve.
-- **Boring over magic**: desconfiar de wrappers/identity helpers/pass-through que agregan indirección sin comprar claridad.
-- **Lógica en la capa correcta**: feature logic no debería filtrarse a shared paths. Usar utilities canónicas en vez de one-offs.
+### 5. Structure and design
+- **1k line rule**: a PR should not push a file from <1k to >1k lines without strong justification. If it crosses, propose decomposing first.
+- **Anti-spaghetti growth**: new ad-hoc conditionals, scattered special cases or one-off branches in unrelated flows = design flag, not a nit.
+- **Radical simplification**: if the behavior can be kept with fewer concepts, branches or layers, look for that path. Prefer the refactor that DELETES complexity over the one that moves it.
+- **Boring over magic**: distrust wrappers/identity helpers/pass-throughs that add indirection without buying clarity.
+- **Logic in the right layer**: feature logic should not leak into shared paths. Use canonical utilities instead of one-offs.
 
 ### 6. Testing
 - Tests for the happy path.

--- a/config/claude/skills/sdd-workflow/scripts/scaffold-sdd.sh
+++ b/config/claude/skills/sdd-workflow/scripts/scaffold-sdd.sh
@@ -10,19 +10,19 @@ set -euo pipefail
 
 FEATURE="${1:-}"
 if [[ ! "$FEATURE" =~ ^[A-Za-z0-9._-]+$ ]]; then
-  echo "Uso: scaffold-sdd.sh <feature-slug>" >&2
+  echo "Usage: scaffold-sdd.sh <feature-slug>" >&2
   exit 2
 fi
 
 TEMPLATE_ROOT="${CLAUDE_TEMPLATE_ROOT:-$HOME/.claude/templates}"
 if [ ! -d "$TEMPLATE_ROOT" ]; then
-  echo "No existe el directorio de plantillas: $TEMPLATE_ROOT" >&2
+  echo "Template directory does not exist: $TEMPLATE_ROOT" >&2
   exit 1
 fi
 
 TARGET="$(pwd)/specs/$FEATURE"
 if [ -e "$TARGET" ]; then
-  echo "Ya existe, no se sobrescribe: $TARGET" >&2
+  echo "Already exists, not overwriting: $TARGET" >&2
   exit 1
 fi
 
@@ -38,10 +38,10 @@ for mapping in \
   source_name="${mapping%%:*}"
   target_name="${mapping#*:}"
   if [ ! -f "$TEMPLATE_ROOT/$source_name" ]; then
-    echo "Falta la plantilla $source_name en $TEMPLATE_ROOT" >&2
+    echo "Missing template $source_name in $TEMPLATE_ROOT" >&2
     exit 1
   fi
   sed "s/{{FEATURE_NAME}}/$FEATURE/g" "$TEMPLATE_ROOT/$source_name" > "$TARGET/$target_name"
 done
 
-echo "Artefactos SDD creados en $TARGET"
+echo "SDD artifacts created in $TARGET"

--- a/config/claude/skills/tanstack-query/SKILL.md
+++ b/config/claude/skills/tanstack-query/SKILL.md
@@ -12,10 +12,10 @@ Rules extracted from auditing 20+ patterns in a legacy codebase. Only what cause
 ### Always an array, hierarchical, with dependencies
 
 ```tsx
-// BAD: string plana, sin dependencias
+// BAD: flat string, no dependencies
 useQuery({ queryKey: 'todos', queryFn: fetchTodos })
 
-// BAD: falta variable en key — colision de cache entre usuarios
+// BAD: missing variable in key — cache collision across users
 useQuery({ queryKey: ['posts'], queryFn: () => fetchPostsByUser(userId) })
 
 // GOOD: hierarchical array, every dependency included
@@ -38,25 +38,25 @@ export const todoKeys = {
   detail: (id: number) => [...todoKeys.all, 'detail', id] as const,
 }
 
-// Uso
+// Usage
 useQuery({ queryKey: todoKeys.list({ status: 'active' }), queryFn: ... })
 
-// Invalidacion precisa
-queryClient.invalidateQueries({ queryKey: todoKeys.all })     // todo
-queryClient.invalidateQueries({ queryKey: todoKeys.detail(5) }) // uno
+// Precise invalidation
+queryClient.invalidateQueries({ queryKey: todoKeys.all })     // everything
+queryClient.invalidateQueries({ queryKey: todoKeys.detail(5) }) // one
 ```
 
 ## Caching
 
 ### staleTime by volatility
 
-| Tipo de dato | staleTime |
+| Data type | staleTime |
 |---|---|
 | Real-time (stocks, feeds) | `0` |
-| Notificaciones | `30s - 1min` |
+| Notifications | `30s - 1min` |
 | UGC (posts, comments) | `1 - 5min` |
-| Referencia (categorias, config) | `10 - 30min` |
-| Estatico | `Infinity` |
+| Reference (categories, config) | `10 - 30min` |
+| Static | `Infinity` |
 
 ```tsx
 // Sensible default, override per query
@@ -70,7 +70,7 @@ Stale data returns instantly. Refetch happens in the background. `staleTime: 0` 
 ### gcTime — retention after unmount
 
 ```tsx
-// Rutas frecuentes: mantener en cache
+// Frequent routes: keep in cache
 useQuery({ queryKey: ['dashboard'], queryFn: ..., gcTime: 30 * 60 * 1000 })
 
 // Large data viewed once: release quickly
@@ -82,13 +82,13 @@ Default 5 min. For SSR: never `gcTime: 0` (2000ms minimum for hydration).
 ### Targeted invalidation, not broad
 
 ```tsx
-// BAD: invalida todo
+// BAD: invalidates everything
 queryClient.invalidateQueries()
 
-// BAD: invalida de mas
+// BAD: invalidates too much
 queryClient.invalidateQueries({ queryKey: ['todos'] })
 
-// GOOD: invalidacion exacta + relacionadas
+// GOOD: exact invalidation + related
 queryClient.invalidateQueries({ queryKey: ['todos', todoId] })
 queryClient.invalidateQueries({ queryKey: ['todos', 'list'] })
 ```
@@ -159,7 +159,7 @@ export function PostList() {
 ```
 
 - A new `QueryClient` per request (avoids leaks between users).
-- `staleTime > 0` en server (previene refetch inmediato en cliente).
+- `staleTime > 0` on the server (prevents an immediate client refetch).
 - Serialize carefully: `JSON.stringify` is XSS-prone. Use a safe serializer.
 
 ## Query Cancellation
@@ -195,7 +195,7 @@ function QueryErrorBoundary({ children }) {
 }
 ```
 
-`useQueryErrorResetBoundary` limpia el estado de error. Sin esto, el retry no funciona.
+`useQueryErrorResetBoundary` clears the error state. Without it, the retry does not work.
 
 ## Prefetching (hover/focus)
 
@@ -211,12 +211,12 @@ Set `staleTime` on the prefetch so it does not refetch immediately. 100ms delay 
 
 ## Cheatsheet
 
-| Problema | Causa probable | Fix |
+| Problem | Likely cause | Fix |
 |---|---|---|
-| Datos stale entre usuarios | Falta variable en queryKey | `queryKey: ['x', userId]` |
+| Stale data across users | Missing variable in queryKey | `queryKey: ['x', userId]` |
 | Refetch on every navigation | `staleTime: 0` (default) | `staleTime: 5 * 60 * 1000` |
-| UI lenta post-mutacion | Esperando refetch | Optimistic update |
+| Slow UI after a mutation | Waiting for the refetch | Optimistic update |
 | Mutation does not refresh the UI | Missing invalidateQueries | Invalidate every affected query |
-| Memory leak en SPA | `gcTime: Infinity` | `gcTime` segun frecuencia de visita |
-| SSR flash de loading | Cliente refetcha tras hydrate | `staleTime > 0` en server |
-| Search input laggy | Requests viejas no canceladas | Pasar `signal` a fetch |
+| Memory leak in an SPA | `gcTime: Infinity` | `gcTime` based on visit frequency |
+| SSR loading flash | Client refetches after hydrate | `staleTime > 0` on the server |
+| Search input laggy | Old requests not cancelled | Pass `signal` to fetch |


### PR DESCRIPTION
## What

Translates every piece of the Claude configuration that the model reads as context from Spanish to English:

- **Markdown context** (14 files): `CLAUDE.md` Session Close, `rules/common/{testing,context-management}.md`, the four `commands/*.md` including their frontmatter `description` and `argument-hint`, four `agents/*.md`, and the `cavecrew` / `code-review` / `tanstack-query` skills.
- **Hook and script output** (18 files): every string emitted to stdout/stderr/JSON by `project-integrations-check.sh`, `validate-safe-ops.sh`, `quality-gate.sh`, `gauntlet-stop.sh`, `secret-detect.sh`, `detect-debug.sh`, `protect-tests.sh`, `protect-codegraph-tracking.sh`, `privacy-review.sh`, the stop/session hooks, both Python hooks, and `rdd.sh` / `validate.sh` / `check-skill-deps.sh` / `scaffold-sdd.sh`.

## Why

Mixed-language instructions degrade instruction following, and `project-integrations-check.sh` injected a Spanish block into the context window on every single prompt. Only the model-facing layer changes; the user-facing layer stays Spanish.

## Deliberately left in Spanish

- Code comments in hooks and scripts (mandated by the global rules; the model does not read them).
- `output-styles/sebita.md` — the Spanish IS the content.
- `skills/inacap/**` (Chilean academic domain), `README.md`, `docs/`, `skill-registry.md`.
- `skills/handoff/SKILL.md` — its instructions were already English; the Spanish is HANDOFF.md content, which line 51 explicitly requires in Spanish because the user reads it.
- Proper nouns in `agents/hr-people-ops.md` and `agents/legal-compliance.md`.

## Test plan

- `make test` → `ALL GREEN` (7 local suites, JSON manifests, skill dependencies, shellcheck).
- `make lint` → exit 0.
- `hooks/project-integrations-check.test.sh` green; its assertions pin `NOT_INITIALIZED`, `NOT_CONFIGURED`, `codegraph init`, `.codegraph/`, all preserved.
- No test file was modified. No control flow, regex or variable was touched — only emitted string literals.
- Diff is 358 insertions / 358 deletions, symmetric as expected for a line-for-line translation.
- Deployed to `~/.claude` and verified 1:1: 323 files identical, permissions unchanged.